### PR TITLE
Add context memory and token storage

### DIFF
--- a/githubClient.js
+++ b/githubClient.js
@@ -22,3 +22,26 @@ exports.repoExists = async function (token, repo) {
     return false;
   }
 };
+
+exports.readFile = async function(token, repo, filePath) {
+  const url = `https://api.github.com/repos/${repo}/contents/${encodeURIComponent(filePath)}`;
+  const res = await axios.get(url, { headers: { Authorization: `token ${token}` } });
+  return Buffer.from(res.data.content, 'base64').toString('utf-8');
+};
+
+exports.writeFile = async function(token, repo, filePath, content, message) {
+  const url = `https://api.github.com/repos/${repo}/contents/${encodeURIComponent(filePath)}`;
+  let sha = undefined;
+  try {
+    const res = await axios.get(url, { headers: { Authorization: `token ${token}` } });
+    sha = res.data.sha;
+  } catch(e) {
+    // file may not exist, ignore
+  }
+  const body = {
+    message: message || `update ${filePath}`,
+    content: Buffer.from(content, 'utf-8').toString('base64'),
+  };
+  if (sha) body.sha = sha;
+  await axios.put(url, body, { headers: { Authorization: `token ${token}` } });
+};

--- a/index.js
+++ b/index.js
@@ -16,6 +16,9 @@ app.post('/saveLessonPlan', memory.saveLessonPlan);
 app.post('/saveNote', memory.saveNote);
 app.post('/getContextSnapshot', memory.getContextSnapshot);
 app.post('/createUserProfile', memory.createUserProfile);
+app.post('/setToken', memory.setToken);
+app.get('/readContext', memory.readContext);
+app.post('/saveContext', memory.saveContext);
 
 app.post('/version/commit', versioning.commitInstructions);
 app.post('/version/rollback', versioning.rollbackInstructions);
@@ -51,6 +54,9 @@ app.get('/docs', (req, res) => {
       "POST /saveNote",
       "POST /getContextSnapshot",
       "POST /createUserProfile",
+      "POST /setToken",
+      "GET /readContext",
+      "POST /saveContext",
       "POST /version/commit",
       "POST /version/rollback",
       "POST /version/list",

--- a/memory.js
+++ b/memory.js
@@ -1,17 +1,36 @@
 
 const fs = require('fs');
 const path = require('path');
+const github = require('./githubClient');
+const tokenStore = require('./tokenStore');
 
 function ensureDir(filePath) {
   const dir = path.dirname(filePath);
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
 }
 
-exports.saveMemory = (req, res) => {
-  const { repo, token, filename, content } = req.body;
+const contextFilename = path.join(__dirname, 'memory', 'context.md');
+
+function ensureContext() {
+  if (!fs.existsSync(contextFilename)) {
+    ensureDir(contextFilename);
+    fs.writeFileSync(contextFilename, '# Context\n', 'utf-8');
+  }
+}
+
+function getToken(req) {
+  if (req.body && req.body.token) return req.body.token;
+  const auth = req.headers['authorization'];
+  if (auth && auth.startsWith('token ')) return auth.slice(6);
+  return tokenStore.getToken();
+}
+
+exports.saveMemory = async (req, res) => {
+  const { repo, filename, content } = req.body;
+  const token = getToken(req);
   console.log('[saveMemory]', new Date().toISOString(), repo, filename);
 
-  if (!repo || !token || !filename || !content) {
+  if (!filename || !content) {
     return res.status(400).json({ status: 'error', message: 'Missing required fields.' });
   }
 
@@ -19,14 +38,32 @@ exports.saveMemory = (req, res) => {
   ensureDir(filePath);
   fs.writeFileSync(filePath, content, 'utf-8');
 
+  if (repo && token) {
+    try {
+      await github.writeFile(token, repo, path.posix.join('memory', filename), content, `update ${filename}`);
+    } catch (e) {
+      console.error('GitHub write error', e.message);
+    }
+  }
+
   res.json({ status: 'success', action: 'saveMemory', filePath });
 };
 
-exports.readMemory = (req, res) => {
-  const { repo, token, filename } = req.body;
+exports.readMemory = async (req, res) => {
+  const { repo, filename } = req.body;
+  const token = getToken(req);
   console.log('[readMemory]', new Date().toISOString(), repo, filename);
 
   const filePath = path.join(__dirname, 'memory', filename);
+  if (repo && token) {
+    try {
+      const content = await github.readFile(token, repo, path.posix.join('memory', filename));
+      return res.json({ status: 'success', action: 'readMemory', content });
+    } catch (e) {
+      console.error('GitHub read error', e.message);
+      // fallback to local
+    }
+  }
   if (!fs.existsSync(filePath)) {
     return res.status(404).json({ status: 'error', message: 'File not found.' });
   }
@@ -80,3 +117,54 @@ exports.createUserProfile = (req, res) => {
   console.log('[createUserProfile]', user);
   res.json({ status: 'success', action: 'createUserProfile' });
 };
+
+exports.setToken = (req, res) => {
+  const { token } = req.body;
+  if (!token) {
+    return res.status(400).json({ status: 'error', message: 'Token required' });
+  }
+  tokenStore.setToken(token);
+  res.json({ status: 'success', action: 'setToken' });
+};
+
+exports.saveContext = async (req, res) => {
+  const { repo, content } = req.body;
+  const token = getToken(req);
+  console.log('[saveContext]', new Date().toISOString(), repo);
+
+  ensureContext();
+  const data = content || '';
+  fs.writeFileSync(contextFilename, data, 'utf-8');
+
+  if (repo && token) {
+    try {
+      await github.writeFile(token, repo, 'memory/context.md', data, 'update context');
+    } catch (e) {
+      console.error('GitHub write context error', e.message);
+    }
+  }
+
+  res.json({ status: 'success', action: 'saveContext' });
+};
+
+exports.readContext = async (req, res) => {
+  const { repo } = req.body;
+  const token = getToken(req);
+  console.log('[readContext]', new Date().toISOString(), repo);
+
+  ensureContext();
+
+  if (repo && token) {
+    try {
+      const content = await github.readFile(token, repo, 'memory/context.md');
+      return res.json({ status: 'success', content });
+    } catch (e) {
+      console.error('GitHub read context error', e.message);
+      // fall back
+    }
+  }
+
+  const content = fs.readFileSync(contextFilename, 'utf-8');
+  res.json({ status: 'success', content });
+};
+

--- a/memory/context.md
+++ b/memory/context.md
@@ -1,0 +1,3 @@
+# Sofia Context
+
+The conversation context will be stored here.

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Sofia Memory Plugin</title>
+</head>
+<body>
+  <h1>Sofia Memory Plugin</h1>
+  <label>GitHub Token:
+    <input type="password" id="token">
+  </label>
+  <button onclick="saveToken()">Save Token</button>
+  <script>
+    function saveToken() {
+      const t = document.getElementById('token').value;
+      localStorage.setItem('github_token', t);
+      fetch('/setToken', {
+        method: 'POST',
+        headers: {'Content-Type':'application/json'},
+        body: JSON.stringify({token: t})
+      });
+      alert('Token saved');
+    }
+    document.addEventListener('DOMContentLoaded', () => {
+      const t = localStorage.getItem('github_token');
+      if (t) document.getElementById('token').value = t;
+    });
+  </script>
+</body>
+</html>

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -37,6 +37,43 @@ paths:
         '200':
           description: Memory read successfully
 
+  /readContext:
+    get:
+      summary: Read conversation context
+      operationId: readContext
+      responses:
+        '200':
+          description: Context read successfully
+  /saveContext:
+    post:
+      summary: Save conversation context
+      operationId: saveContext
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SaveContextRequest"
+      responses:
+        '200':
+          description: Context saved successfully
+  /setToken:
+    post:
+      summary: Store GitHub token for future requests
+      operationId: setToken
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                token:
+                  type: string
+      responses:
+        '200':
+          description: Token stored
+
 components:
   schemas:
     SaveMemoryRequest:
@@ -64,3 +101,13 @@ components:
         filename:
           type: string
           example: memory/test.md
+
+    SaveContextRequest:
+      type: object
+      properties:
+        repo:
+          type: string
+        content:
+          type: string
+
+

--- a/tokenStore.js
+++ b/tokenStore.js
@@ -1,0 +1,7 @@
+let storedToken = process.env.GITHUB_TOKEN || null;
+
+exports.setToken = (token) => {
+  storedToken = token;
+};
+
+exports.getToken = () => storedToken;


### PR DESCRIPTION
## Summary
- create public token entry page
- support saving GitHub token on server
- implement context file with read/save endpoints
- allow reading/writing to GitHub
- document new endpoints in OpenAPI

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6851a67556ec832385671a93a4cd3a4b