### PR TITLE
Add GET endpoint for reading memory

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ app.use(express.static(path.join(__dirname, 'public')));
 app.use(bodyParser.json());
 
 app.post('/saveMemory', memory.saveMemory);
+app.get('/readMemory', memory.readMemoryGET); // new GET endpoint
 app.post('/readMemory', memory.readMemory);
 app.post('/setMemoryRepo', memory.setMemoryRepo);
 app.post('/saveLessonPlan', memory.saveLessonPlan);
@@ -48,6 +49,7 @@ app.get('/docs', (req, res) => {
   res.json({
     endpoints: [
       "POST /saveMemory",
+      "GET /readMemory",
       "POST /readMemory",
       "POST /setMemoryRepo",
       "POST /saveLessonPlan",

--- a/memory.js
+++ b/memory.js
@@ -77,6 +77,34 @@ exports.readMemory = async (req, res) => {
   res.json({ status: 'success', action: 'readMemory', content });
 };
 
+// Read memory content using query parameters (GET version)
+exports.readMemoryGET = async (req, res) => {
+  const { repo, filename, token } = req.query;
+  console.log('[readMemoryGET]', new Date().toISOString(), repo, filename);
+
+  const normalizedFilename = filename && filename.startsWith('memory/')
+    ? filename
+    : `memory/${filename}`;
+  const filePath = path.join(__dirname, normalizedFilename);
+
+  const authToken = token || getToken(req);
+  if (repo && authToken) {
+    try {
+      const content = await github.readFile(authToken, repo, normalizedFilename);
+      return res.json({ status: 'success', action: 'readMemoryGET', content });
+    } catch (e) {
+      console.error('GitHub read error', e.message);
+    }
+  }
+
+  if (!fs.existsSync(filePath)) {
+    return res.status(404).json({ status: 'error', message: 'File not found.' });
+  }
+
+  const content = fs.readFileSync(filePath, 'utf-8');
+  res.json({ status: 'success', action: 'readMemoryGET', content });
+};
+
 exports.setMemoryRepo = (req, res) => {
   const { repoUrl } = req.body;
   console.log('[setMemoryRepo]', repoUrl);

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -37,6 +37,30 @@ paths:
         '200':
           description: Memory read successfully
 
+  /readMemory:
+    get:
+      summary: Read memory content using GET
+      operationId: readMemoryGET
+      parameters:
+        - name: repo
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: token
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: filename
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Memory read successfully
+
 components:
   schemas:
     SaveMemoryRequest:

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -37,6 +37,30 @@ paths:
         '200':
           description: Memory read successfully
 
+  /readMemory:
+    get:
+      summary: Read memory content using GET
+      operationId: readMemoryGET
+      parameters:
+        - name: repo
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: token
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: filename
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Memory read successfully
+
   /readContext:
     get:
       summary: Read conversation context


### PR DESCRIPTION
## Summary
- implement `readMemoryGET` handler and register `/readMemory` GET route
- document GET route in `/docs` output
- describe `readMemoryGET` in OpenAPI specs

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852f9abf5d48323b086ce34f8e1d457