### PR TITLE
Add endpoint to list markdown files in repo

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const express = require('express');
 const path = require('path');
 const bodyParser = require('body-parser');
 const memory = require('./memory');
+const { listMemoryFiles } = require('./memory');
 const versioning = require('./versioning');
 
 const app = express();
@@ -19,6 +20,20 @@ app.post('/createUserProfile', memory.createUserProfile);
 app.post('/setToken', memory.setToken);
 app.get('/readContext', memory.readContext);
 app.post('/saveContext', memory.saveContext);
+
+app.post('/list', async (req, res) => {
+  try {
+    const { repo, token, path } = req.body;
+    if (!repo || !token || !path) {
+      return res.status(400).json({ error: 'Missing repo, token, or path' });
+    }
+
+    const fileList = await listMemoryFiles(repo, token, path);
+    return res.json({ status: 'success', files: fileList });
+  } catch (error) {
+    return res.status(500).json({ error: error.message });
+  }
+});
 
 app.post('/version/commit', versioning.commitInstructions);
 app.post('/version/rollback', versioning.rollbackInstructions);
@@ -60,6 +75,7 @@ app.get('/docs', (req, res) => {
       "POST /version/commit",
       "POST /version/rollback",
       "POST /version/list",
+      "POST /list",
       "GET /ping",
       "GET /docs"
     ]

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -37,6 +37,31 @@ paths:
         '200':
           description: Memory read successfully
 
+  /list:
+    post:
+      summary: List memory files in a directory
+      operationId: listMemoryFiles
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ListMemoryRequest"
+      responses:
+        "200":
+          description: List of files returned successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  files:
+                    type: array
+                    items:
+                      type: string
+
 components:
   schemas:
     SaveMemoryRequest:
@@ -64,3 +89,17 @@ components:
         filename:
           type: string
           example: memory/test.md
+
+    ListMemoryRequest:
+      type: object
+      properties:
+        repo:
+          type: string
+        token:
+          type: string
+        path:
+          type: string
+      required:
+        - repo
+        - token
+        - path


### PR DESCRIPTION
## Summary
- add `/list` endpoint to list markdown files in a directory
- implement `listMemoryFiles` in `memory.js`
- extend OpenAPI spec for new endpoint and request schema
- document endpoint in `/docs`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68531adf211083239d04c6dc03bf3759