### PR TITLE
Add plan.json progress tracking

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ app.post('/createUserProfile', memory.createUserProfile);
 app.post('/setToken', memory.setToken);
 app.get('/readContext', memory.readContext);
 app.post('/saveContext', memory.saveContext);
+app.get('/plan', memory.readPlan);
 
 app.post('/list', async (req, res) => {
   try {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -62,6 +62,37 @@ paths:
                     items:
                       type: string
 
+  /saveLessonPlan:
+    post:
+      summary: Update learning plan with completed lesson
+      operationId: saveLessonPlan
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SaveLessonPlanRequest"
+      responses:
+        "200":
+          description: Plan updated successfully
+
+  /plan:
+    get:
+      summary: Read current plan information
+      operationId: readPlan
+      responses:
+        "200":
+          description: Current plan contents
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  plan:
+                    type: object
+
 components:
   schemas:
     SaveMemoryRequest:
@@ -103,3 +134,19 @@ components:
         - repo
         - token
         - path
+
+    SaveLessonPlanRequest:
+      type: object
+      properties:
+        title:
+          type: string
+        summary:
+          type: string
+        projectFiles:
+          type: array
+          items:
+            type: string
+        plannedLessons:
+          type: array
+          items:
+            type: string


### PR DESCRIPTION
## Summary
- handle plan.json creation and updating
- expose new `/plan` endpoint
- document plan endpoints in openapi spec

## Testing
- `node -e "require('./memory'); console.log('load ok');"`
- `node -e "require('./index'); setTimeout(()=>process.exit(),1000);"`
- `node - <<'NODE'
const memory = require('./memory');
memory.saveLessonPlan({body:{title:'Lesson1', summary:'ok', projectFiles:['a.js'], plannedLessons:['Lesson2']}}, {json: console.log});
NODE`


------
https://chatgpt.com/codex/tasks/task_e_6853277973788323b216a0d43fff08bf