### PR TITLE
Refactor index generation

### DIFF
--- a/githubClient.js
+++ b/githubClient.js
@@ -46,29 +46,3 @@ exports.writeFile = async function(token, repo, filePath, content, message) {
   await axios.put(url, body, { headers: { Authorization: `token ${token}` } });
 };
 
-exports.listFilesInDirectory = async function(repo, token, directoryPath) {
-  const url = `https://api.github.com/repos/${repo}/contents/${encodeURIComponent(directoryPath)}`;
-  console.log('[listFilesInDirectory]', new Date().toISOString(), repo, directoryPath);
-
-  try {
-    const res = await axios.get(url, {
-      headers: {
-        Authorization: `token ${token}`,
-        Accept: 'application/vnd.github.v3+json'
-      }
-    });
-
-    return res.data.map(item => ({
-      name: item.name,
-      path: item.path,
-      type: item.type
-    }));
-  } catch (e) {
-    if (e.response && e.response.status === 404) {
-      console.error('[listFilesInDirectory] Directory not found:', directoryPath);
-      throw new Error('Directory not found');
-    }
-    console.error('[listFilesInDirectory]', e.message);
-    throw e;
-  }
-};


### PR DESCRIPTION
## Summary
- maintain index.json using local updates only
- drop repo scanning and GitHub directory listing
- update plan and context functions to refresh the index

## Testing
- `npm test` *(fails: Missing script)*
- `node -e "require('./memory')"`

------
https://chatgpt.com/codex/tasks/task_e_68533951b3e08323b0e0805f950b8b77