### PR TITLE
Implement recursive memory indexing

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -185,10 +185,6 @@ components:
     UpdateIndexRequest:
       type: object
       properties:
-        repo:
-          type: string
-        token:
-          type: string
         entries:
           type: array
           items:


### PR DESCRIPTION
## Summary
- recursively scan memory folder and collect files
- update index entries on file save
- expose helpers and update manual index route
- adjust OpenAPI schema for `/updateIndex`

## Testing
- `npm test` *(fails: Missing script)*
- `node -e "require('./memory'); console.log('loaded');"`

------
https://chatgpt.com/codex/tasks/task_e_6853d70dbc6c832391cc3fdee0512024