### PR TITLE
Improve index management for Sofia memory plugin

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -79,7 +79,7 @@ paths:
   /updateIndex:
     post:
       summary: Manually update index.json
-      operationId: updateIndexFileManually
+      operationId: updateIndexManual
       requestBody:
         required: true
         content:
@@ -189,5 +189,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/IndexEntry'
+        repo:
+          type: string
+        token:
+          type: string
       required:
         - entries


### PR DESCRIPTION
## Summary
- add robust index update functions and error logging
- update `saveMemory` to refresh GitHub index entries
- support manual index updates with repo/token
- document updated behaviour in OpenAPI spec

## Testing
- `node -e "require('./memory.js'); console.log('loaded');"`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6853e4b54c6883238f9551d677097aef