### PR TITLE
Add frontend token input and main.js

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,25 +6,12 @@
 </head>
 <body>
   <h1>Sofia Memory Plugin</h1>
-  <label>GitHub Token:
-    <input type="password" id="token">
+  <label for="github-token">GitHub Token:
+    <input type="password" id="github-token" />
   </label>
-  <button onclick="saveToken()">Save Token</button>
-  <script>
-    function saveToken() {
-      const t = document.getElementById('token').value;
-      localStorage.setItem('github_token', t);
-      fetch('/setToken', {
-        method: 'POST',
-        headers: {'Content-Type':'application/json'},
-        body: JSON.stringify({token: t})
-      });
-      alert('Token saved');
-    }
-    document.addEventListener('DOMContentLoaded', () => {
-      const t = localStorage.getItem('github_token');
-      if (t) document.getElementById('token').value = t;
-    });
-  </script>
+  <button id="save-token">Save Token</button>
+  <span id="token-status"></span>
+
+  <script src="main.js"></script>
 </body>
 </html>

--- a/public/main.js
+++ b/public/main.js
@@ -1,0 +1,66 @@
+(function(){
+  const tokenInput = document.getElementById('github-token');
+  const saveBtn = document.getElementById('save-token');
+  const statusEl = document.getElementById('token-status');
+
+  function showStatus(text, success){
+    if(!statusEl) return;
+    statusEl.textContent = text;
+    statusEl.style.color = success ? 'green' : 'red';
+    setTimeout(() => { statusEl.textContent = ''; }, 2000);
+  }
+
+  function saveToken(){
+    const token = tokenInput ? tokenInput.value.trim() : '';
+    if(!token){
+      showStatus('Token required', false);
+      return;
+    }
+    localStorage.setItem('github_token', token);
+    showStatus('Token saved', true);
+  }
+
+  function restoreToken(){
+    const stored = localStorage.getItem('github_token');
+    if(stored && tokenInput){
+      tokenInput.value = stored;
+    }
+  }
+
+  function getToken(){
+    return localStorage.getItem('github_token') || '';
+  }
+
+  async function saveMemory(repo, filename, content){
+    const token = getToken();
+    if(!token) throw new Error('GitHub token not set');
+    const res = await fetch('/save', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token, repo, filename, content })
+    });
+    if(!res.ok) throw new Error('Save failed');
+    return res.json();
+  }
+
+  async function readMemory(repo, filename){
+    const token = getToken();
+    if(!token) throw new Error('GitHub token not set');
+    const res = await fetch('/read', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token, repo, filename })
+    });
+    if(!res.ok) throw new Error('Read failed');
+    return res.json();
+  }
+
+  // expose globals
+  window.saveToken = saveToken;
+  window.getToken = getToken;
+  window.saveMemory = saveMemory;
+  window.readMemory = readMemory;
+
+  document.addEventListener('DOMContentLoaded', restoreToken);
+  if(saveBtn) saveBtn.addEventListener('click', saveToken);
+})();


### PR DESCRIPTION
## Summary
- add new `public/main.js` to manage GitHub token and to add it to `/save` and `/read` requests
- update `public/index.html` to include token form and the new script

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68546026a3c08323a872f5fdb9e38e46