### PR TITLE
Add server-side GitHub token storage and UI updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.cache/
+token.json
+

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ app.post('/saveNote', memory.saveNote);
 app.post('/getContextSnapshot', memory.getContextSnapshot);
 app.post('/createUserProfile', memory.createUserProfile);
 app.post('/setToken', memory.setToken);
+app.get('/token/status', memory.tokenStatus);
 app.get('/readContext', memory.readContext);
 app.post('/saveContext', memory.saveContext);
 app.post('/updateIndex', memory.updateIndexManual);
@@ -83,6 +84,7 @@ app.get('/docs', (req, res) => {
       "POST /getContextSnapshot",
       "POST /createUserProfile",
       "POST /setToken",
+      "GET /token/status",
       "GET /readContext",
       "POST /saveContext",
       "POST /version/commit",

--- a/memory.js
+++ b/memory.js
@@ -654,12 +654,14 @@ exports.createUserProfile = (req, res) => {
 };
 
 exports.setToken = (req, res) => {
-  const { token } = req.body;
-  if (!token) {
-    return res.status(400).json({ status: 'error', message: 'Token required' });
-  }
+  const token = req.body && req.body.token ? req.body.token : '';
   tokenStore.setToken(token);
-  res.json({ status: 'success', action: 'setToken' });
+  res.json({ status: 'success', action: 'setToken', connected: !!token });
+};
+
+exports.tokenStatus = (req, res) => {
+  const token = tokenStore.getToken();
+  res.json({ connected: !!token });
 };
 
 exports.readPlan = (req, res) => {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -107,6 +107,38 @@ paths:
                   plan:
                     type: object
 
+  /setToken:
+    post:
+      summary: Store GitHub token on the server
+      operationId: setToken
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                token:
+                  type: string
+      responses:
+        "200":
+          description: Token stored
+
+  /token/status:
+    get:
+      summary: Check if a token is stored on the server
+      operationId: tokenStatus
+      responses:
+        "200":
+          description: Token status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  connected:
+                    type: boolean
+
 components:
   schemas:
     SaveMemoryRequest:

--- a/public/index.html
+++ b/public/index.html
@@ -6,10 +6,14 @@
 </head>
 <body>
   <h1>Sofia Memory Plugin</h1>
-  <label for="github-token">GitHub Token:
-    <input type="password" id="github-token" />
-  </label>
-  <button id="save-token">Save Token</button>
+  <div id="token-section">
+    <label for="github-token">GitHub Token:
+      <input type="password" id="github-token" />
+    </label>
+    <button id="save-token">Save Token</button>
+  </div>
+  <button id="logout" style="display:none;">Log Out</button>
+  <button id="clear-local">Clear token (local)</button>
   <span id="token-status"></span>
 
   <script src="main.js"></script>

--- a/public/main.js
+++ b/public/main.js
@@ -1,30 +1,64 @@
+
 (function(){
   const tokenInput = document.getElementById('github-token');
   const saveBtn = document.getElementById('save-token');
   const statusEl = document.getElementById('token-status');
+  const tokenSection = document.getElementById('token-section');
+  const logoutBtn = document.getElementById('logout');
+  const clearLocalBtn = document.getElementById('clear-local');
 
-  function showStatus(text, success){
+  function setStatus(connected){
     if(!statusEl) return;
-    statusEl.textContent = text;
-    statusEl.style.color = success ? 'green' : 'red';
-    setTimeout(() => { statusEl.textContent = ''; }, 2000);
+    statusEl.textContent = connected ? 'Connected' : 'Disconnected';
+    statusEl.style.color = connected ? 'green' : 'red';
+  }
+
+  async function sendToken(token){
+    await fetch('/setToken', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token })
+    });
+  }
+
+  function updateUI(){
+    const has = !!localStorage.getItem('github_token');
+    setStatus(has);
+    if(tokenSection) tokenSection.style.display = has ? 'none' : 'block';
+    if(logoutBtn) logoutBtn.style.display = has ? 'inline' : 'none';
   }
 
   function saveToken(){
     const token = tokenInput ? tokenInput.value.trim() : '';
     if(!token){
-      showStatus('Token required', false);
+      setStatus(false);
       return;
     }
     localStorage.setItem('github_token', token);
-    showStatus('Token saved', true);
+    sendToken(token);
+    updateUI();
   }
 
   function restoreToken(){
     const stored = localStorage.getItem('github_token');
     if(stored && tokenInput){
       tokenInput.value = stored;
+      sendToken(stored);
     }
+    updateUI();
+  }
+
+  function logout(){
+    localStorage.removeItem('github_token');
+    if(tokenInput) tokenInput.value = '';
+    sendToken('');
+    updateUI();
+  }
+
+  function clearLocal(){
+    localStorage.removeItem('github_token');
+    if(tokenInput) tokenInput.value = '';
+    updateUI();
   }
 
   function getToken(){
@@ -63,4 +97,6 @@
 
   document.addEventListener('DOMContentLoaded', restoreToken);
   if(saveBtn) saveBtn.addEventListener('click', saveToken);
+  if(logoutBtn) logoutBtn.addEventListener('click', logout);
+  if(clearLocalBtn) clearLocalBtn.addEventListener('click', clearLocal);
 })();

--- a/tokenStore.js
+++ b/tokenStore.js
@@ -1,15 +1,22 @@
 const fs = require('fs');
 const path = require('path');
 
-const tokenFile = path.join(__dirname, 'token.json');
+const cacheDir = path.join(__dirname, '.cache');
+const tokenFile = path.join(cacheDir, 'token.txt');
 let storedToken = null;
 
+function ensureDir() {
+  if (!fs.existsSync(cacheDir)) {
+    fs.mkdirSync(cacheDir, { recursive: true });
+  }
+}
+
 function loadToken() {
-  if (storedToken) return storedToken;
+  if (storedToken !== null) return storedToken;
   if (fs.existsSync(tokenFile)) {
     try {
-      const data = JSON.parse(fs.readFileSync(tokenFile, 'utf-8'));
-      storedToken = data.token || null;
+      const data = fs.readFileSync(tokenFile, 'utf-8').trim();
+      storedToken = data || null;
     } catch (e) {
       storedToken = null;
     }
@@ -18,15 +25,20 @@ function loadToken() {
 }
 
 function saveToken(token) {
+  ensureDir();
   try {
-    fs.writeFileSync(tokenFile, JSON.stringify({ token }), 'utf-8');
+    if (token) {
+      fs.writeFileSync(tokenFile, token, 'utf-8');
+    } else if (fs.existsSync(tokenFile)) {
+      fs.unlinkSync(tokenFile);
+    }
   } catch (e) {
     console.error('[tokenStore] failed to save token', e.message);
   }
 }
 
 exports.setToken = (token) => {
-  storedToken = token;
+  storedToken = token || null;
   saveToken(token);
 };
 


### PR DESCRIPTION
## Summary
- persist tokens on the server using `.cache/token.txt`
- expose `POST /setToken` and `GET /token/status` endpoints
- update client UI with connect/disconnect handling
- hide token field when connected and add logout/clear buttons
- document the new endpoints in `openapi.yaml`
- ignore `.cache` and token files in git

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68546a7e02a08323ae4beb60677132e3