### PR TITLE
Add token management endpoints

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ app.post('/getContextSnapshot', memory.getContextSnapshot);
 app.post('/createUserProfile', memory.createUserProfile);
 app.post('/setToken', memory.setToken);
 app.get('/token/status', memory.tokenStatus);
+app.get('/tokenStatus', memory.tokenStatus); // alias for /token/status
 app.get('/readContext', memory.readContext);
 app.post('/saveContext', memory.saveContext);
 app.post('/updateIndex', memory.updateIndexManual);

--- a/memory.js
+++ b/memory.js
@@ -655,12 +655,18 @@ exports.createUserProfile = (req, res) => {
 
 exports.setToken = (req, res) => {
   const token = req.body && req.body.token ? req.body.token : '';
+  if (token) {
+    console.log('[setToken] token updated');
+  } else {
+    console.log('[setToken] token cleared or missing');
+  }
   tokenStore.setToken(token);
   res.json({ status: 'success', action: 'setToken', connected: !!token });
 };
 
 exports.tokenStatus = (req, res) => {
   const token = tokenStore.getToken();
+  console.log('[tokenStatus]', !!token);
   res.json({ connected: !!token });
 };
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -139,6 +139,21 @@ paths:
                   connected:
                     type: boolean
 
+  /tokenStatus:
+    get:
+      summary: Check if a token is stored on the server
+      operationId: tokenStatus
+      responses:
+        "200":
+          description: Token status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  connected:
+                    type: boolean
+
 components:
   schemas:
     SaveMemoryRequest:

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -74,6 +74,21 @@ paths:
         '200':
           description: Token stored
 
+  /tokenStatus:
+    get:
+      summary: Check if a token is stored on the server
+      operationId: tokenStatus
+      responses:
+        '200':
+          description: Token status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  connected:
+                    type: boolean
+
 components:
   schemas:
     SaveMemoryRequest:


### PR DESCRIPTION
## Summary
- expose `/tokenStatus` endpoint in public and root OpenAPI specs
- log token updates and status checks
- alias `/tokenStatus` to `/token/status`

## Testing
- `npm start` *(fails: npm attempted to access the internet)*

------
https://chatgpt.com/codex/tasks/task_e_68546dd2ce548323a593a1937b4da17d