### PR TITLE
Refactor plan storage to markdown

### DIFF
--- a/memory/plan.md
+++ b/memory/plan.md
@@ -1,0 +1,11 @@
+# Learning Plan (Sofia Tutor)
+
+## Completed Lessons
+
+
+## Requested Clarifications
+
+
+## Progress
+Completed: 0 lessons  
+Next lesson: 


### PR DESCRIPTION
## Summary
- migrate lesson plan storage from JSON to Markdown
- parse markdown plan and update from index.json
- adjust saveLessonPlan logic for new structure

## Testing
- `node --check memory.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854fa328f0883238dc9e0a4f9815d09