### PR TITLE
Improve plan generation logic

### DIFF
--- a/memory/index.json
+++ b/memory/index.json
@@ -1,1 +1,27 @@
-[]
+[
+  {
+    "path": "memory/context.md",
+    "type": "context",
+    "title": "Sofia Context",
+    "description": " The conversation context will be stored here.",
+    "lastModified": "2025-06-20T06:37:30.489Z"
+  },
+  {
+    "path": "memory/plan.md",
+    "type": "plan",
+    "title": "Learning Plan",
+    "description": " ## Completed Topics",
+    "lastModified": "2025-06-20T06:39:45.153Z"
+  },
+  {
+    "path": "memory/test.md",
+    "type": "lesson",
+    "description": "",
+    "lastModified": "2025-06-20T06:37:30.489Z"
+  },
+  {
+    "path": "memory/test.txt",
+    "type": "lesson",
+    "lastModified": "2025-06-20T06:37:30.489Z"
+  }
+]

--- a/memory/plan.md
+++ b/memory/plan.md
@@ -1,11 +1,10 @@
-# Learning Plan (Sofia Tutor)
+# Learning Plan
 
-## Completed Lessons
+## Completed Topics
+- test.md
+- test.txt
+
+## Clarified or Expanded Topics
 
 
-## Requested Clarifications
-
-
-## Progress
-Completed: 0 lessons  
-Next lesson: 
+## Progress: 2 / 2 lessons complete


### PR DESCRIPTION
## Summary
- normalize nested memory paths
- compute lessons from index.json when generating plan
- update plan and progress format
- refresh plan on memory save and plan read
- adjust token fallback behavior

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855019b56348323b764ff51d064cbfe