### PR TITLE
Improve index merging and plan tracking

### DIFF
--- a/memory/index.json
+++ b/memory/index.json
@@ -1,27 +1,4 @@
 [
-  {
-    "path": "memory/context.md",
-    "type": "context",
-    "title": "Sofia Context",
-    "description": " The conversation context will be stored here.",
-    "lastModified": "2025-06-20T06:37:30.489Z"
-  },
-  {
-    "path": "memory/plan.md",
-    "type": "plan",
-    "title": "Learning Plan",
-    "description": " ## Completed Topics",
-    "lastModified": "2025-06-20T06:39:45.153Z"
-  },
-  {
-    "path": "memory/test.md",
-    "type": "lesson",
-    "description": "",
-    "lastModified": "2025-06-20T06:37:30.489Z"
-  },
-  {
-    "path": "memory/test.txt",
-    "type": "lesson",
-    "lastModified": "2025-06-20T06:37:30.489Z"
-  }
+  { "path": "memory/test.md", "title": "Test lesson", "lastModified": "2025-06-20T06:37:30.489Z" },
+  { "path": "memory/test.txt", "title": "Text lesson", "lastModified": "2025-06-20T06:37:30.489Z" }
 ]

--- a/memory/plan.md
+++ b/memory/plan.md
@@ -1,10 +1,4 @@
-# Learning Plan
-
-## Completed Topics
-- test.md
-- test.txt
-
-## Clarified or Expanded Topics
-
-
-## Progress: 2 / 2 lessons complete
+{
+  "done": ["test.md", "test.txt"],
+  "upcoming": []
+}


### PR DESCRIPTION
## Summary
- avoid overwriting index.json by merging local/remote data
- persist lesson plan progress in JSON format
- add helper to update plan with GitHub merge
- clean up saveMemory and saveLessonPlan flows
- add debug logging and directory checks

## Testing
- `node -e "require('./memory.js')"`
- `node -e "require('./indexManager.js')"`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68552d27e8c88323874b71656facec67