### PR TITLE
Add per-user memory config via chat

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ app.get('/token/status', memory.tokenStatus);
 app.get('/tokenStatus', memory.tokenStatus); // alias for /token/status
 app.get('/readContext', memory.readContext);
 app.post('/saveContext', memory.saveContext);
+app.post('/chat/setup', memory.chatSetupCommand);
 app.post('/updateIndex', memory.updateIndexManual);
 app.get('/plan', memory.readPlan);
 
@@ -93,6 +94,7 @@ app.get('/docs', (req, res) => {
       "POST /version/list",
       "POST /list",
       "POST /updateIndex",
+      "POST /chat/setup",
       "GET /debug/index",
       "GET /ping",
       "GET /docs"

--- a/indexManager.js
+++ b/indexManager.js
@@ -115,10 +115,10 @@ async function removeEntry(p) {
   indexData = indexData.filter(e => e.path !== p);
 }
 
-async function saveIndex(repo, token) {
+async function saveIndex(repo, token, userId) {
   if (!indexData) await loadIndex();
-  const finalRepo = repo || memoryConfig.getRepoUrl();
-  const finalToken = token || tokenStore.getToken();
+  const finalRepo = repo || memoryConfig.getRepoUrl(userId);
+  const finalToken = token || tokenStore.getToken(userId);
 
   let remoteData = [];
   if (finalRepo && finalToken) {


### PR DESCRIPTION
## Summary
- support storing GitHub tokens and repo URLs per user
- parse chat commands to set token and repo for a user
- adjust memory functions to use per-user context
- expose setup route and document it

## Testing
- `node -e "require('./memory.js');"`
- `node -e "require('./index.js');"` *(terminated after startup)*
- `npm test` *(fails: Missing script and no network access)*

------
https://chatgpt.com/codex/tasks/task_e_68553c6985608323900c55c0605e15d5