### PR TITLE
Implement memory setup parser

### DIFF
--- a/memory.js
+++ b/memory.js
@@ -959,21 +959,16 @@ async function updateIndexManual(req, res) {
 
 function chatSetupCommand(req, res) {
   const text = req.body && req.body.text ? req.body.text : '';
-  const regex = /set memory for (\S+) repo (https:\/\/github\.com\/[^\s]+\.git) token (ghp_[A-Za-z0-9]+)/i;
-  const match = text.match(regex);
-  if (!match) {
+  const { parseUserMemorySetup } = require('./utils');
+  const parsed = parseUserMemorySetup(text);
+  if (!parsed) {
     return res.status(400).json({ status: 'error', message: 'Invalid command' });
   }
-  const [, userId, repoUrl, token] = match;
-  if (!/^ghp_[A-Za-z0-9]+$/.test(token) || !/^https:\/\/github\.com\/[\w.-]+\/[\w.-]+\.git$/.test(repoUrl)) {
-    return res.status(400).json({ status: 'error', message: 'Invalid repo or token format' });
-  }
-  tokenStore.setToken(userId, token);
-  memoryConfig.setRepoUrl(userId, repoUrl);
+  const { userId, repo } = parsed;
   return res.json({
     status: 'success',
     message: `Memory configured for user: ${userId}`,
-    repo: repoUrl
+    repo
   });
 }
 

--- a/utils.js
+++ b/utils.js
@@ -1,3 +1,51 @@
 // Utility helpers for Sofia memory plugin
-// (empty for now)
+
+const tokenStore = require('./tokenStore');
+const memoryConfig = require('./memoryConfig');
+
+/**
+ * Parse a chat command that configures memory settings for a user.
+ *
+ * Expected format (order may vary):
+ *   "set memory for <userId> repo <repoUrl> token <ghp_xxx>"
+ *
+ * @param {string} message - raw chat text
+ * @returns {{userId: string, repo: string, token: string}|null}
+ */
+function parseUserMemorySetup(message = '') {
+  if (typeof message !== 'string') return null;
+
+  const userMatch = message.match(/(?:for|user)\s+([\w_]+)/i);
+  const repoMatch = message.match(/repo\s+(https?:\/\/github\.com\/[\w.-]+\/[\w.-]+\.git\/?)/i);
+  const tokenMatch = message.match(/token\s+(ghp_[A-Za-z0-9]+)/i);
+
+  if (!userMatch || !repoMatch || !tokenMatch) return null;
+
+  const userId = userMatch[1];
+  let repo = repoMatch[1].replace(/\/?$/, '');
+  const token = tokenMatch[1];
+
+  if (!/^[\w_]+$/.test(userId)) {
+    console.warn('[parseUserMemorySetup] invalid userId', userId);
+    return null;
+  }
+  if (!/^ghp_[A-Za-z0-9]+$/.test(token)) {
+    console.warn('[parseUserMemorySetup] invalid token format');
+    return null;
+  }
+  if (!/^https:\/\/github\.com\/[\w.-]+\/[\w.-]+\.git$/.test(repo)) {
+    console.warn('[parseUserMemorySetup] invalid repo url');
+    return null;
+  }
+
+  tokenStore.setToken(userId, token);
+  memoryConfig.setRepoUrl(userId, repo);
+  console.log(`[MemorySetup] Configured user: ${userId}`);
+
+  return { userId, repo, token };
+}
+
+module.exports = {
+  parseUserMemorySetup
+};
 


### PR DESCRIPTION
## Summary
- add `parseUserMemorySetup` util for chat command parsing and auto-configure token/repo
- use new parser in `chatSetupCommand`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855439e578883239d21701e05a1b97b