### PR TITLE
Prevent index pollution

### DIFF
--- a/indexManager.js
+++ b/indexManager.js
@@ -97,6 +97,16 @@ async function loadIndex() {
 
 async function addOrUpdateEntry(entry) {
   if (!entry || !entry.path) return;
+  const p = entry.path.replace(/\\/g, '/');
+  if (!p.startsWith('memory/')) return;
+  if (p.includes('/sofia-memory-plugin/')) return;
+  if (p.includes('__tests__')) return;
+  if (
+    p.includes('context.md') ||
+    p.includes('test.md') ||
+    p.includes('test.txt')
+  )
+    return;
   if (!indexData) await loadIndex();
   const idx = indexData.findIndex(e => e.path === entry.path);
   const base = { lastModified: new Date().toISOString() };

--- a/memory.js
+++ b/memory.js
@@ -65,19 +65,6 @@ async function githubWriteFileSafe(token, repo, relPath, data, message, attempts
       ensureDir(path.join(__dirname, path.dirname(relPath)));
       await github.writeFile(token, repo, relPath, data, message);
       logDebug('[githubWriteFileSafe] pushed', relPath);
-      if (
-        relPath.startsWith('memory/') &&
-        relPath !== 'memory/index.json'
-      ) {
-        await indexManager.addOrUpdateEntry({
-          path: relPath,
-          title: generateTitleFromPath(relPath),
-          type: inferTypeFromPath(relPath),
-          lastModified: new Date().toISOString()
-        });
-        await indexManager.saveIndex(repo, token);
-        console.log(`[index] Updated for ${relPath}`);
-      }
       return;
     } catch (e) {
       console.error(`[githubWriteFileSafe] attempt ${i} failed for ${relPath}`, e.message);


### PR DESCRIPTION
## Summary
- avoid adding plugin files to index.json
- update the index only after user saveMemory actions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68555dbe26088323926e6fc649442a0f