### PR TITLE
Add saveMemoryWithIndex helper

### DIFF
--- a/indexManager.js
+++ b/indexManager.js
@@ -57,16 +57,19 @@ function normalizeMemoryPath(p) {
 }
 
 function generateTitleFromPath(p) {
-  const base = path.basename(p, path.extname(p));
-  return base.charAt(0).toUpperCase() + base.slice(1);
+  return p
+    .split('/')
+    .pop()
+    .replace(/\..+$/, '')
+    .replace(/[-_]/g, ' ')
+    .replace(/\b\w/g, l => l.toUpperCase());
 }
 
 function inferTypeFromPath(p) {
-  const lower = p.toLowerCase();
-  if (lower.includes('plan')) return 'plan';
-  if (lower.includes('profile')) return 'profile';
-  if (lower.includes('lesson')) return 'lesson';
-  if (lower.includes('notes')) return 'note';
+  if (p.includes('plan')) return 'plan';
+  if (p.includes('profile')) return 'profile';
+  if (p.includes('lesson')) return 'lesson';
+  if (p.includes('note')) return 'note';
   return 'file';
 }
 
@@ -200,6 +203,7 @@ async function saveMemoryWithIndex(userId, repo, token, filename, content) {
     lastModified: new Date().toISOString()
   });
   await saveIndex(finalRepo, finalToken, userId);
+  console.log(`[Memory] Saved and indexed: ${normalized}`);
   return normalized;
 }
 

--- a/memory.js
+++ b/memory.js
@@ -46,16 +46,19 @@ function normalizeMemoryPath(p) {
 }
 
 function generateTitleFromPath(p) {
-  const base = path.basename(p, path.extname(p));
-  return base.charAt(0).toUpperCase() + base.slice(1);
+  return p
+    .split('/')
+    .pop()
+    .replace(/\..+$/, '')
+    .replace(/[-_]/g, ' ')
+    .replace(/\b\w/g, l => l.toUpperCase());
 }
 
 function inferTypeFromPath(p) {
-  const lower = p.toLowerCase();
-  if (lower.includes('plan')) return 'plan';
-  if (lower.includes('profile')) return 'profile';
-  if (lower.includes('lesson')) return 'lesson';
-  if (lower.includes('notes')) return 'note';
+  if (p.includes('plan')) return 'plan';
+  if (p.includes('profile')) return 'profile';
+  if (p.includes('lesson')) return 'lesson';
+  if (p.includes('note')) return 'note';
   return 'file';
 }
 


### PR DESCRIPTION
## Summary
- update title & type inference helpers
- log when saving and indexing files
- expose helper to save and index in one call

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685561e208fc8323985d09e947479b95