### PR TITLE
Fix index merging before save

### DIFF
--- a/memory.js
+++ b/memory.js
@@ -785,7 +785,7 @@ async function saveMemory(req, res) {
         type: inferTypeFromPath(normalizedFilename),
         lastModified: new Date().toISOString()
       });
-      await indexManager.saveIndex(effectiveRepo, token);
+      await indexManager.saveIndex(token, effectiveRepo);
       console.log(`[index] Updated for ${normalizedFilename}`);
     }
   } catch (e) {


### PR DESCRIPTION
## Summary
- merge the remote `index.json` before saving so previous entries aren't lost
- update `saveMemory` usage for new `saveIndex` signature

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855771bf2dc8323ba188632e0073aa4