### PR TITLE
Prevent index.json data loss

### DIFF
--- a/memory.js
+++ b/memory.js
@@ -215,8 +215,7 @@ function sanitizeIndex(entries) {
     if (EXCLUDED.has(normalized)) return;
     const abs = path.join(__dirname, normalized);
     if (!fs.existsSync(abs)) {
-      console.warn(`[sanitizeIndex] missing file ${normalized}, removing`);
-      return;
+      console.warn(`[sanitizeIndex] missing file ${normalized}, keeping entry`);
     }
     const existing = map.get(normalized);
     if (!existing || new Date(e.lastModified || 0) > new Date(existing.lastModified || 0)) {


### PR DESCRIPTION
## Summary
- keep index entries even when local files are missing

## Testing
- `node -c memory.js`
- `node -c indexManager.js`


------
https://chatgpt.com/codex/tasks/task_e_6855a69a87f48323899c4afe27b8bd84