### PR TITLE
Implement auto context restore

### DIFF
--- a/Instruction.md
+++ b/Instruction.md
@@ -1,1 +1,1 @@
-11. If context is incomplete, GPT automatically calls `restoreContext()` to reload plan, profile, and lesson from memory.
+11. GPT must call `restoreContext()` when context is lost. If `TEST_MODE` is enabled, confirm with the user before restoring.

--- a/context.js
+++ b/context.js
@@ -36,23 +36,38 @@ async function readFile(filePath, opts = {}) {
 
 /**
  * Restore plan, profile and current lesson from memory.
- * @param {object} [opts] optional parameters
+ * @param {boolean} [debug=false] enable verbose logging
+ * @param {object} [opts] optional readFile parameters
  * @returns {Promise<{plan:string|null, profile:string|null, currentLesson:string|null}>}
  */
-async function restoreContext(opts = {}) {
+async function restoreContext(debug = false, opts = {}) {
   try {
-    const indexRaw = await readFile('memory/index.json', opts);
+    const indexPath = 'memory/index.json';
+    if (debug) console.log('[restoreContext] loading', indexPath);
+    const indexRaw = await readFile(indexPath, opts);
     const index = JSON.parse(indexRaw);
 
     const planPath = index['plan'];
     const profilePath = index['profile'];
     const currentLessonPath = index['currentLesson'];
 
+    if (debug) {
+      console.log('[restoreContext] plan path', planPath);
+      console.log('[restoreContext] profile path', profilePath);
+      console.log('[restoreContext] lesson path', currentLessonPath);
+    }
+
     const [plan, profile, lesson] = await Promise.all([
       planPath ? readFile(planPath, opts).catch(() => null) : Promise.resolve(null),
       profilePath ? readFile(profilePath, opts).catch(() => null) : Promise.resolve(null),
       currentLessonPath ? readFile(currentLessonPath, opts).catch(() => null) : Promise.resolve(null)
     ]);
+
+    if (debug) {
+      console.log('[restoreContext] loaded plan', !!plan);
+      console.log('[restoreContext] loaded profile', !!profile);
+      console.log('[restoreContext] loaded lesson', !!lesson);
+    }
 
     return { plan, profile, currentLesson: lesson };
   } catch (e) {
@@ -61,4 +76,50 @@ async function restoreContext(opts = {}) {
   }
 }
 
-module.exports = { restoreContext, readFile };
+function fileEmpty(p) {
+  return !fs.existsSync(p) || !fs.readFileSync(p, 'utf-8').trim();
+}
+
+function shouldRestoreContext({ userPrompt = '', gptOutput = '', tokensSinceLastRead = 0 } = {}) {
+  try {
+    const idxPath = path.join(__dirname, 'memory', 'index.json');
+    if (fileEmpty(idxPath)) return true;
+    const index = JSON.parse(fs.readFileSync(idxPath, 'utf-8'));
+    const planPath = path.join(__dirname, index.plan || '');
+    const profilePath = path.join(__dirname, index.profile || '');
+    if (fileEmpty(planPath) || fileEmpty(profilePath)) return true;
+  } catch {
+    return true;
+  }
+
+  if (tokensSinceLastRead > 3000) return true;
+
+  const promptTriggers = [/restore context/i, /!debug-restore/i, /did you forget/i];
+  if (promptTriggers.some(r => r.test(userPrompt))) return true;
+
+  const gptTriggers = [/what lesson\??/i, /which lesson/i, /memory loss/i];
+  if (gptTriggers.some(r => r.test(gptOutput))) return true;
+
+  return false;
+}
+
+async function maybeRestoreContext({ debug = false, testMode = false, userPrompt = '', gptOutput = '', tokensSinceLastRead = 0 } = {}) {
+  if (!shouldRestoreContext({ userPrompt, gptOutput, tokensSinceLastRead })) {
+    return { restored: false };
+  }
+
+  if (testMode) {
+    console.log('⚠️ I detected missing context. Do you want me to restore it from memory?');
+    return { restored: false, confirmationNeeded: true };
+  }
+
+  const context = await restoreContext(debug);
+  return { restored: true, context };
+}
+
+module.exports = {
+  restoreContext,
+  readFile,
+  shouldRestoreContext,
+  maybeRestoreContext
+};


### PR DESCRIPTION
## Summary
- extend `restoreContext` with debug logging and add context loss detection helpers
- update instructions for restoring context automatically

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855ef1efe148323987faa02670f7f45