### PR TITLE
Improve context restore using index

### DIFF
--- a/context.js
+++ b/context.js
@@ -40,41 +40,85 @@ async function readFile(filePath, opts = {}) {
  * @param {object} [opts] optional readFile parameters
  * @returns {Promise<{plan:string|null, profile:string|null, currentLesson:string|null}>}
  */
-async function restoreContext(debug = false, opts = {}) {
-  try {
-    const indexPath = 'memory/index.json';
-    if (debug) console.log('[restoreContext] loading', indexPath);
-    const indexRaw = await readFile(indexPath, opts);
-    const index = JSON.parse(indexRaw);
+  async function restoreContext(debug = false, opts = {}) {
+    try {
+      const indexPath = 'memory/index.json';
+      if (debug) console.log('[restoreContext] loading', indexPath);
+      const indexRaw = await readFile(indexPath, opts);
+      let index;
+      try {
+        index = JSON.parse(indexRaw);
+      } catch (e) {
+        if (debug) console.error('[restoreContext] failed to parse index', e.message);
+        index = {};
+      }
 
-    const planPath = index['plan'];
-    const profilePath = index['profile'];
-    const currentLessonPath = index['currentLesson'];
+      let planPath;
+      let profilePath;
+      let currentLessonPath;
+      const restored = [];
+      const skipped = [];
 
-    if (debug) {
-      console.log('[restoreContext] plan path', planPath);
-      console.log('[restoreContext] profile path', profilePath);
-      console.log('[restoreContext] lesson path', currentLessonPath);
+      if (Array.isArray(index)) {
+        const lessons = [];
+        index.forEach(entry => {
+          if (!entry || !entry.path) return;
+          const abs = path.join(__dirname, entry.path);
+          if (!fs.existsSync(abs)) {
+            if (debug) skipped.push(`${entry.path} (missing)`);
+            return;
+          }
+          const type = entry.type || '';
+          if (type && type !== 'lesson' && type !== 'plan') {
+            if (debug) skipped.push(`${entry.path} (type ${type})`);
+            return;
+          }
+          restored.push(entry.path);
+          if (!planPath && (type === 'plan' || /plan\.md$/i.test(entry.path))) {
+            planPath = entry.path;
+          } else if (!profilePath && (type === 'profile' || /profile\.md$/i.test(entry.path))) {
+            profilePath = entry.path;
+          }
+          if (type === 'lesson' || /lesson/i.test(entry.path)) {
+            lessons.push(entry);
+          }
+        });
+
+        lessons.sort((a, b) => new Date(b.lastModified || 0) - new Date(a.lastModified || 0));
+        if (lessons.length) currentLessonPath = lessons[0].path;
+      } else {
+        planPath = index.plan;
+        profilePath = index.profile;
+        currentLessonPath = index.currentLesson;
+        if (debug) restored.push(planPath, profilePath, currentLessonPath);
+      }
+
+      if (debug) {
+        console.log('[restoreContext] plan path', planPath);
+        console.log('[restoreContext] profile path', profilePath);
+        console.log('[restoreContext] lesson path', currentLessonPath);
+      }
+
+      const [plan, profile, lesson] = await Promise.all([
+        planPath ? readFile(planPath, opts).catch(() => null) : Promise.resolve(null),
+        profilePath ? readFile(profilePath, opts).catch(() => null) : Promise.resolve(null),
+        currentLessonPath ? readFile(currentLessonPath, opts).catch(() => null) : Promise.resolve(null)
+      ]);
+
+      if (debug) {
+        console.log('[restoreContext] loaded plan', !!plan);
+        console.log('[restoreContext] loaded profile', !!profile);
+        console.log('[restoreContext] loaded lesson', !!lesson);
+        console.log('[restoreContext] restored', restored.filter(Boolean).length, 'files');
+        if (skipped.length) console.log('[restoreContext] skipped', skipped.join(', '));
+      }
+
+      return { plan, profile, currentLesson: lesson };
+    } catch (e) {
+      console.error('[restoreContext]', e.message);
+      return { plan: null, profile: null, currentLesson: null };
     }
-
-    const [plan, profile, lesson] = await Promise.all([
-      planPath ? readFile(planPath, opts).catch(() => null) : Promise.resolve(null),
-      profilePath ? readFile(profilePath, opts).catch(() => null) : Promise.resolve(null),
-      currentLessonPath ? readFile(currentLessonPath, opts).catch(() => null) : Promise.resolve(null)
-    ]);
-
-    if (debug) {
-      console.log('[restoreContext] loaded plan', !!plan);
-      console.log('[restoreContext] loaded profile', !!profile);
-      console.log('[restoreContext] loaded lesson', !!lesson);
-    }
-
-    return { plan, profile, currentLesson: lesson };
-  } catch (e) {
-    console.error('[restoreContext]', e.message);
-    return { plan: null, profile: null, currentLesson: null };
   }
-}
 
 function fileEmpty(p) {
   return !fs.existsSync(p) || !fs.readFileSync(p, 'utf-8').trim();
@@ -85,8 +129,23 @@ function shouldRestoreContext({ userPrompt = '', gptOutput = '', tokensSinceLast
     const idxPath = path.join(__dirname, 'memory', 'index.json');
     if (fileEmpty(idxPath)) return true;
     const index = JSON.parse(fs.readFileSync(idxPath, 'utf-8'));
-    const planPath = path.join(__dirname, index.plan || '');
-    const profilePath = path.join(__dirname, index.profile || '');
+    let planPath = '';
+    let profilePath = '';
+    if (Array.isArray(index)) {
+      for (const entry of index) {
+        if (!entry || !entry.path) continue;
+        if (!planPath && (entry.type === 'plan' || /plan\.md$/i.test(entry.path))) {
+          planPath = entry.path;
+        } else if (!profilePath && (entry.type === 'profile' || /profile\.md$/i.test(entry.path))) {
+          profilePath = entry.path;
+        }
+      }
+    } else {
+      planPath = index.plan;
+      profilePath = index.profile;
+    }
+    planPath = planPath ? path.join(__dirname, planPath) : '';
+    profilePath = profilePath ? path.join(__dirname, profilePath) : '';
     if (fileEmpty(planPath) || fileEmpty(profilePath)) return true;
   } catch {
     return true;

--- a/memory/index.json
+++ b/memory/index.json
@@ -1,5 +1,17 @@
-{
-  "plan": "memory/plan.md",
-  "profile": "memory/profile.md",
-  "currentLesson": "memory/lessons/04_example.md"
-}
+[
+  {
+    "path": "memory/plan.md",
+    "type": "plan",
+    "title": "Learning Plan"
+  },
+  {
+    "path": "memory/profile.md",
+    "type": "profile",
+    "title": "Profile"
+  },
+  {
+    "path": "memory/lessons/04_example.md",
+    "type": "lesson",
+    "title": "Example Lesson"
+  }
+]


### PR DESCRIPTION
## Summary
- load index.json as array of entries to restore context
- check existence and filter by type when selecting plan/profile/lesson
- update shouldRestoreContext to work with entry array
- convert sample index.json to array format

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68564ef8d2f88323b40ebfcea47b0e8c