### PR TITLE
Add dual repo support

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,10 @@
+{
+  "studentRepo": {
+    "repo": "https://github.com/STUDENT/REPO.git",
+    "token": "ghp_STUDENT_TOKEN"
+  },
+  "pluginRepo": {
+    "repo": "https://github.com/redvampir/sofia-memory-plugin.git",
+    "token": "ghp_PLUGIN_TOKEN"
+  }
+}

--- a/rootConfig.js
+++ b/rootConfig.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+
+const configFile = path.join(__dirname, 'config.json');
+let cached = undefined;
+
+function loadConfig() {
+  if (cached !== undefined) return cached;
+  if (fs.existsSync(configFile)) {
+    try {
+      const raw = fs.readFileSync(configFile, 'utf-8');
+      cached = JSON.parse(raw);
+    } catch {
+      cached = null;
+    }
+  } else {
+    cached = null;
+  }
+  return cached;
+}
+
+function getPluginRepo() {
+  const cfg = loadConfig();
+  return cfg && cfg.pluginRepo ? cfg.pluginRepo : null;
+}
+
+function getStudentRepo() {
+  const cfg = loadConfig();
+  return cfg && cfg.studentRepo ? cfg.studentRepo : null;
+}
+
+module.exports = {
+  loadConfig,
+  getPluginRepo,
+  getStudentRepo,
+};


### PR DESCRIPTION
## Summary
- allow loading of plugin and student repo settings from new `config.json`
- add helper `rootConfig.js` to parse the shared config
- update memory functions to select repo/token based on path
- include default `config.json`

## Testing
- `node test/instructions_test.js`
- `node test/repo_context_test.js`


------
https://chatgpt.com/codex/tasks/task_e_68579a1dd6b08323910abf5a9cc76a26