### PR TITLE
Implement markdown backup system

### DIFF
--- a/instructionsManager.js
+++ b/instructionsManager.js
@@ -4,6 +4,7 @@ const { execSync } = require('child_process');
 const simpleGit = require('simple-git');
 const github = require('./githubClient');
 const repoConfig = require('./instructionsRepoConfig');
+const mdEditor = require('./markdownEditor');
 
 const git = simpleGit();
 const SKIP_GIT = process.env.NO_GIT === "true";
@@ -52,6 +53,7 @@ async function loadFromGitHub(repo = DEFAULT_REPO, token, file = DEFAULT_FILE, v
   }
   const content = await github.readFile(token, repo, file);
   const dest = versionPath(version);
+  mdEditor.createBackup(dest);
   fs.writeFileSync(dest, content, 'utf-8');
   if (!SKIP_GIT) {
     await git.add(dest);
@@ -147,6 +149,7 @@ async function edit(version, newContent, opts = {}) {
   }
 
   if (!devMode) saveHistory(version);
+  mdEditor.createBackup(dest);
   fs.writeFileSync(dest, newContent, 'utf-8');
 
   if (devMode) {

--- a/memory.js
+++ b/memory.js
@@ -51,6 +51,9 @@ function ensureDir(filePath) {
 function writeFileSafe(filePath, data) {
   try {
     ensureDir(filePath);
+    if (filePath.toLowerCase().endsWith('.md')) {
+      mdEditor.createBackup(filePath);
+    }
     fs.writeFileSync(filePath, data, 'utf-8');
     logDebug('[writeFileSafe] wrote', filePath);
   } catch (e) {


### PR DESCRIPTION
## Summary
- add git-aware backup mechanism to `markdownEditor`
- automatically create backups before overwriting markdown files
- integrate backups in `instructionsManager` load/edit

## Testing
- `node test/instructions_test.js`
- `node test/repo_context_test.js`


------
https://chatgpt.com/codex/tasks/task_e_6857ac8f96b8832388c78e1a950d2253