### PR TITLE
Extend markdown editing features

### DIFF
--- a/markdownEditor.js
+++ b/markdownEditor.js
@@ -57,6 +57,12 @@ function markChecklistItem(filePath, heading, itemText, checked = true) {
     filePath
   );
 
+  const current = lines[idx];
+  if (/^[-*]\s+\[[xX]\]/.test(current) && checked) {
+    console.log('ℹ️ Info: Task already marked as complete. No update necessary.');
+    return false;
+  }
+
   createBackup(filePath);
   lines[idx] = `- [${checked ? 'x' : ' '}] ${itemText}`;
   fs.writeFileSync(filePath, lines.join('\n'), 'utf-8');

--- a/markdownValidator.js
+++ b/markdownValidator.js
@@ -13,6 +13,11 @@ function checkFileExists(filePath) {
 
 function validateMarkdownSyntax(content, filePath) {
   const lines = Array.isArray(content) ? content : content.split(/\r?\n/);
+  if (lines.length === 1 && lines[0].trim() === '') {
+    console.warn('⚠️ Warning: File exists but is empty. No content to validate.');
+    return true;
+  }
+
   let valid = true;
   for (const line of lines) {
     const t = line.trim();

--- a/memory.js
+++ b/memory.js
@@ -824,28 +824,26 @@ async function saveMemory(req, res) {
   const isMarkdown = normalizedFilename.endsWith('.md');
   if (isMarkdown) {
     try {
-      const indexEntries = await fetchIndex(effectiveRepo, effectiveToken);
-      const entry = indexEntries.find(
-        (e) => e.path === normalizedFilename && e.type === 'plan'
-      );
-      if (entry) {
-        let existing = '';
-        if (effectiveRepo && effectiveToken) {
-          try {
-            existing = await github.readFile(effectiveToken, effectiveRepo, normalizedFilename);
-          } catch (e) {
-            logDebug('[saveMemory] no remote file', e.message);
-          }
+      let existing = '';
+      if (effectiveRepo && effectiveToken) {
+        try {
+          existing = await github.readFile(
+            effectiveToken,
+            effectiveRepo,
+            normalizedFilename
+          );
+        } catch (e) {
+          logDebug('[saveMemory] no remote file', e.message);
         }
-        if (!existing && fs.existsSync(filePath)) {
-          existing = fs.readFileSync(filePath, 'utf-8');
-        }
-        if (existing) {
-          const baseTree = parseMarkdownStructure(existing);
-          const newTree = parseMarkdownStructure(content);
-          const merged = mergeMarkdownTrees(baseTree, newTree);
-          finalContent = serializeMarkdownTree(merged);
-        }
+      }
+      if (!existing && fs.existsSync(filePath)) {
+        existing = fs.readFileSync(filePath, 'utf-8');
+      }
+      if (existing) {
+        const baseTree = parseMarkdownStructure(existing);
+        const newTree = parseMarkdownStructure(content);
+        const merged = mergeMarkdownTrees(baseTree, newTree);
+        finalContent = serializeMarkdownTree(merged);
       }
     } catch (e) {
       console.error('[saveMemory] markdown merge failed', e.message);

--- a/test/markdown_update_test.js
+++ b/test/markdown_update_test.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const mdEditor = require('../markdownEditor');
+const validator = require('../markdownValidator');
+
+const tmpDir = path.join(__dirname, 'tmp');
+if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir);
+
+async function run() {
+  // Empty file handling
+  const emptyPath = path.join(tmpDir, 'empty.md');
+  fs.writeFileSync(emptyPath, '');
+  validator.validateMarkdownSyntax(fs.readFileSync(emptyPath, 'utf-8'), emptyPath);
+
+  // Already completed task
+  const checklist = path.join(tmpDir, 'checklist.md');
+  fs.writeFileSync(checklist, '# Test\n## Tasks\n- [x] Sample');
+  const updated = mdEditor.markChecklistItem(checklist, 'Tasks', 'Sample');
+  assert.strictEqual(updated, false);
+
+  // Adding a new task
+  const sectionFile = path.join(tmpDir, 'section.md');
+  fs.writeFileSync(sectionFile, '# Plan\n\n## 🟡 In Progress\n');
+  mdEditor.insertSection(sectionFile, '🟡 In Progress', ['- [ ] New Task']);
+  const content = fs.readFileSync(sectionFile, 'utf-8');
+  assert.ok(content.includes('- [ ] New Task'));
+
+  console.log('markdown update tests passed');
+}
+
+run();


### PR DESCRIPTION
## Summary
- warn when validating empty markdown files
- skip checklist updates when task is already complete
- merge markdown for all `.md` files, not just plans
- add tests covering validator/editor behavior

## Testing
- `node test/markdown_update_test.js`
- `node test/instructions_test.js`
- `node test/repo_context_test.js`


------
https://chatgpt.com/codex/tasks/task_e_6857bf158aa08323872c2bfdc44f4c94