### PR TITLE
Enhance markdown editor

### DIFF
--- a/test/markdownEditor.test.js
+++ b/test/markdownEditor.test.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const mdEditor = require('../markdownEditor');
+
+const tmpDir = path.join(__dirname, 'tmp');
+if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir);
+
+async function run() {
+  // Replace content between comment markers
+  const blockFile = path.join(tmpDir, 'block.md');
+  fs.writeFileSync(blockFile, 'Intro\n<!--start-->\nold text\n<!--end-->\nOutro');
+  mdEditor.updateMarkdownFile({
+    filePath: blockFile,
+    startMarker: '<!--start-->',
+    endMarker: '<!--end-->',
+    newContent: 'new text'
+  });
+  const blockContent = fs.readFileSync(blockFile, 'utf-8');
+  assert.ok(blockContent.includes('new text'));
+  assert.ok(!blockContent.includes('old text'));
+  assert.ok(blockContent.includes('<!--start-->'));
+  assert.ok(blockContent.includes('<!--end-->'));
+
+  // Replace checklist items under a heading
+  const checklistFile = path.join(tmpDir, 'tasks.md');
+  fs.writeFileSync(checklistFile, '# Title\n\n## Tasks\n- [ ] old\n## Done');
+  mdEditor.updateMarkdownFile({
+    filePath: checklistFile,
+    startMarker: '## Tasks',
+    endMarker: '## Done',
+    newContent: '- [x] new item'
+  });
+  const checklistContent = fs.readFileSync(checklistFile, 'utf-8');
+  assert.ok(checklistContent.includes('- [x] new item'));
+  assert.ok(!checklistContent.includes('- [ ] old'));
+
+  console.log('markdownEditor tests passed');
+}
+
+run();


### PR DESCRIPTION
## Summary
- extend markdownEditor with `updateMarkdownFile` for partial updates
- add tests for comment block replacement and checklist replacement

## Testing
- `node test/markdown_update_test.js`
- `node test/markdownEditor.test.js`
- `node test/repo_context_test.js`
- `node test/instructions_test.js`

------
https://chatgpt.com/codex/tasks/task_e_6857cb55e8108323acde566d2d18298e