### PR TITLE
Add markdown file editor module

### DIFF
--- a/markdownFileEditor.js
+++ b/markdownFileEditor.js
@@ -1,0 +1,171 @@
+const fs = require('fs');
+const path = require('path');
+const validator = require('./markdownValidator');
+const mdEditor = require('./markdownEditor');
+const {
+  parseMarkdownStructure,
+  serializeMarkdownTree,
+  mergeMarkdownTrees
+} = require('./markdownMergeEngine.ts');
+
+function loadTree(filePath) {
+  validator.checkFileExists(filePath);
+  const raw = fs.readFileSync(filePath, 'utf-8');
+  validator.validateMarkdownSyntax(raw, filePath);
+  const tree = parseMarkdownStructure(raw);
+  return tree;
+}
+
+function writeTree(filePath, tree) {
+  const content = serializeMarkdownTree(tree);
+  validator.validateMarkdownSyntax(content, filePath);
+  mdEditor.createBackup(filePath);
+  fs.writeFileSync(filePath, content, 'utf-8');
+}
+
+function findHeading(nodes, heading) {
+  for (const node of nodes) {
+    if (node.type === 'heading' && node.text === heading) return node;
+    if (node.children) {
+      const found = findHeading(node.children, heading);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+function addTask(filePath, heading, taskText, checked = false) {
+  const tree = loadTree(filePath);
+  let h = findHeading(tree, heading);
+  if (!h) {
+    h = { type: 'heading', level: 2, text: heading, children: [] };
+    tree.push(h);
+  }
+  if (!h.children) h.children = [];
+  const exists = (n) =>
+    n.type === 'list' && n.children.some((c) => c.type === 'item' && c.text === taskText);
+  if (!h.children.find(exists)) {
+    h.children.push({
+      type: 'list',
+      level: 0,
+      text: '',
+      children: [{ type: 'item', level: 0, text: taskText, checked }]
+    });
+  }
+  writeTree(filePath, tree);
+}
+
+function removeTask(filePath, heading, taskText) {
+  const tree = loadTree(filePath);
+  const h = findHeading(tree, heading);
+  if (!h) return;
+
+  function remove(nodes) {
+    return nodes.filter((n) => {
+      if (n.type === 'item' && n.text === taskText) {
+        return false;
+      }
+      if (n.children) n.children = remove(n.children);
+      return true;
+    });
+  }
+
+  if (h.children) h.children = remove(h.children);
+  writeTree(filePath, tree);
+}
+
+function addSection(filePath, heading, lines) {
+  const tree = loadTree(filePath);
+  let h = findHeading(tree, heading);
+  const sectionTree = parseMarkdownStructure(['## ' + heading, ...lines].join('\n'));
+  if (!h) {
+    tree.push(sectionTree[0]);
+  } else {
+    h.children = mergeMarkdownTrees(h.children || [], sectionTree[0].children || []);
+  }
+  writeTree(filePath, tree);
+}
+
+function removeSection(filePath, heading) {
+  const tree = loadTree(filePath);
+  const stack = [{ nodes: tree }];
+  while (stack.length) {
+    const { nodes } = stack.pop();
+    const idx = nodes.findIndex(n => n.type === 'heading' && n.text === heading);
+    if (idx >= 0) {
+      nodes.splice(idx, 1);
+      writeTree(filePath, tree);
+      return;
+    }
+    for (const n of nodes) if (n.children) stack.push({ nodes: n.children });
+  }
+}
+
+function translateContent(filePath, map) {
+  const tree = loadTree(filePath);
+  const walk = nodes => {
+    for (const n of nodes) {
+      if (n.type === 'heading' || n.type === 'item') {
+        if (map[n.text]) n.text = map[n.text];
+      }
+      if (n.children) walk(n.children);
+    }
+  };
+  walk(tree);
+  writeTree(filePath, tree);
+}
+
+function dedupeTree(nodes) {
+  const seenHeadings = new Map();
+  const result = [];
+  for (const node of nodes) {
+    if (node.type === 'heading') {
+      const key = `${node.level}:${node.text}`;
+      if (seenHeadings.has(key)) {
+        const existing = seenHeadings.get(key);
+        existing.children = mergeMarkdownTrees(existing.children || [], node.children || []);
+        continue;
+      } else {
+        seenHeadings.set(key, node);
+      }
+    }
+    if (node.type === 'item') {
+      // handled in dedupeItems
+    }
+    if (node.children) node.children = dedupeTree(node.children);
+    result.push(node);
+  }
+  return dedupeItems(result);
+}
+
+function dedupeItems(nodes) {
+  const result = [];
+  const seen = new Map();
+  for (const node of nodes) {
+    if (node.type === 'item') {
+      const key = node.text.toLowerCase();
+      if (seen.has(key)) {
+        if (node.checked) seen.get(key).checked = true;
+        continue;
+      }
+      seen.set(key, node);
+    }
+    result.push(node);
+  }
+  return result;
+}
+
+function cleanDuplicates(filePath) {
+  const tree = loadTree(filePath);
+  const cleaned = dedupeTree(tree);
+  writeTree(filePath, cleaned);
+}
+
+module.exports = {
+  addTask,
+  removeTask,
+  addSection,
+  removeSection,
+  translateContent,
+  cleanDuplicates
+};

--- a/test/markdown_file_editor.test.js
+++ b/test/markdown_file_editor.test.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const editor = require('../markdownFileEditor');
+
+const tmpDir = path.join(__dirname, 'tmp_file_editor');
+if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir);
+
+function read(p){return fs.readFileSync(p,'utf-8');}
+
+async function run(){
+  const file = path.join(tmpDir,'sample.md');
+  fs.writeFileSync(file, '# Title\n\n## Tasks\n- [ ] Item\n- [x] Done\n\n## Extra\n- [ ] English');
+
+  editor.addTask(file, 'Tasks', 'New Task');
+  assert.ok(read(file).includes('New Task'));
+
+  editor.removeTask(file, 'Tasks', 'Item');
+  const cont1 = read(file);
+  assert.ok(!cont1.includes('Item'));
+
+  editor.addSection(file, 'Section', ['- [ ] Sub']);
+  assert.ok(read(file).includes('Section'));
+
+  editor.translateContent(file, { 'English': 'Русский' });
+  assert.ok(read(file).includes('Русский'));
+
+  fs.appendFileSync(file, '\n\n## Section\n- [ ] Sub');
+  editor.cleanDuplicates(file);
+  const cont2 = read(file);
+  assert.strictEqual(cont2.match(/## Section/g).length, 1);
+
+  console.log('markdown file editor tests passed');
+}
+
+run();


### PR DESCRIPTION
## Summary
- implement `markdownFileEditor` for editing markdown sections and tasks
- add tests covering the new module

## Testing
- `node test/markdownEditor.test.js`
- `node test/markdown_file_editor.test.js`
- `node test/markdown_update_test.js`
- `node test/repo_context_test.js`
- `for f in test/*.js; do node $f; done`

------
https://chatgpt.com/codex/tasks/task_e_6857d25f8ce48323904766ee2e5bdcb9