### PR TITLE
Enhance markdown editing

### DIFF
--- a/test/markdown_file_editor.test.js
+++ b/test/markdown_file_editor.test.js
@@ -22,6 +22,16 @@ async function run(){
   editor.addSection(file, 'Section', ['- [ ] Sub']);
   assert.ok(read(file).includes('Section'));
 
+  editor.toggleTaskStatus(file, 'Tasks', 'New Task', true);
+  assert.ok(read(file).includes('- [x] New Task'));
+
+  editor.updateTaskText(file, 'Tasks', 'New Task', 'Updated Task');
+  assert.ok(read(file).includes('Updated Task'));
+
+  editor.addSectionPath(file, ['Section', 'Subsection'], ['- [ ] Child']);
+  const txt = read(file);
+  assert.ok(txt.includes('Subsection'));
+
   editor.translateContent(file, { 'English': 'Русский' });
   assert.ok(read(file).includes('Русский'));
 


### PR DESCRIPTION
## Summary
- improve markdown file editor to prevent data loss
- add functions for toggling and editing checklist items
- support nested section insertion
- update tests for new editing features

## Testing
- `node test/markdown_file_editor.test.js`
- `node test/markdownEditor.test.js`
- `node test/instructions_test.js`
- `node test/markdown_update_test.js`
- `node test/repo_context_test.js`


------
https://chatgpt.com/codex/tasks/task_e_6857d4f41488832389512c1d4fee6a09