### PR TITLE
Add checklist translation support

### DIFF
--- a/test/checklist_translation.test.js
+++ b/test/checklist_translation.test.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const editor = require('../markdownFileEditor');
+
+const tmpDir = path.join(__dirname, 'tmp_translate');
+if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir);
+
+(async function run(){
+  const file = path.join(tmpDir,'list.md');
+  const content = [
+    '# Title',
+    '- [ ] Translate this item',
+    '- [ ] Перевести этот пункт',
+    '- [x] Done in English',
+    '- [ ] plan.md',
+    '- [ ] Random item'
+  ].join('\n');
+  fs.writeFileSync(file, content);
+
+  const map = {
+    'Translate this item':'Перевести этот пункт',
+    'Done in English':'Выполнено'
+  };
+  editor.translateChecklistItems(file, map);
+  const out = fs.readFileSync(file,'utf-8');
+  assert.ok(!out.includes('Translate this item'));
+  assert.ok(out.includes('Перевести этот пункт'));
+  assert.ok(out.includes('- [x] Выполнено'));
+  assert.ok(out.includes('plan.md')); // skipped
+  assert.ok(out.includes('## Untranslated'));
+  assert.ok(out.includes('- [ ] Random item'));
+  console.log('checklist translation test passed');
+})();


### PR DESCRIPTION
## Summary
- translate checklist items using a provided map
- log items without translations
- add tests for new checklist translation feature

## Testing
- `node test/checklist_translation.test.js`
- `node test/markdown_file_editor.test.js`
- `node test/markdownEditor.test.js`
- `node test/markdown_update_test.js`
- `node test/full_markdown_editing.test.js`
- `node test/instructions_test.js`
- `node test/repo_context_test.js`


------
https://chatgpt.com/codex/tasks/task_e_6857fcb3d2c08323a145386421bee953