### PR TITLE
Enhance markdown checklist editing

### DIFF
--- a/memory.js
+++ b/memory.js
@@ -6,6 +6,7 @@ const memoryConfig = require('./memoryConfig');
 const indexManager = require('./indexManager');
 const rootConfig = require('./rootConfig');
 const mdEditor = require('./markdownEditor');
+const fileEditor = require('./markdownFileEditor');
 const {
   parseMarkdownStructure,
   mergeMarkdownTrees,
@@ -1212,5 +1213,6 @@ module.exports = {
   markdownEditor: mdEditor,
   markChecklistItem: mdEditor.markChecklistItem,
   insertSection: mdEditor.insertSection,
-  createBackup: mdEditor.createBackup
+  createBackup: mdEditor.createBackup,
+  fileEditor
 };

--- a/test/structural_checklist_editing.test.js
+++ b/test/structural_checklist_editing.test.js
@@ -1,0 +1,44 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const editor = require('../markdownFileEditor');
+
+const tmpDir = path.join(__dirname, 'tmp_struct');
+if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir);
+
+(async function run(){
+  const file = path.join(tmpDir, 'list.md');
+  fs.writeFileSync(file, '# Title\n\n## Tasks\n- [ ] old');
+
+  // 1. add new unchecked item under existing section
+  editor.insertTask(file, 'Tasks', 'new');
+  let content = fs.readFileSync(file,'utf-8');
+  assert.ok(content.includes('- [ ] new'));
+
+  // 2. mark task as completed without duplication
+  editor.updateChecklistItem(file, 'Tasks', 'old', { checked: true });
+  content = fs.readFileSync(file,'utf-8');
+  assert.ok(content.includes('- [x] old'));
+  assert.strictEqual(content.match(/old/g).length, 1);
+
+  // 3. remove a task by partial label match
+  editor.removeTaskMatch(file, 'Tasks', 'new');
+  content = fs.readFileSync(file,'utf-8');
+  assert.ok(!content.includes('new'));
+
+  // 4. add subtasks maintaining indentation
+  editor.insertTask(file, 'Tasks', 'Main');
+  editor.insertTask(file, 'Tasks', 'Sub1', { parent:'Main' });
+  editor.insertTask(file, 'Tasks', 'Sub2', { parent:'Main', checked:true });
+  content = fs.readFileSync(file,'utf-8');
+  assert.ok(/Main\n  - \[ \] Sub1/.test(content));
+  assert.ok(/Main\n(?:.*\n)*  - \[x\] Sub2/.test(content));
+
+  // 5. insert into newly created section
+  editor.insertTask(file, 'Extra', 'first');
+  content = fs.readFileSync(file,'utf-8');
+  assert.ok(content.includes('## Extra'));
+  assert.ok(content.includes('- [ ] first'));
+
+  console.log('structural checklist update tests passed');
+})();


### PR DESCRIPTION
## Summary
- extend `markdownFileEditor` with structured checklist functions
- expose new file editor API via `memory.js`
- add tests for checklist structural editing

## Testing
- `node test/markdown_update_test.js`
- `node test/markdown_file_editor.test.js`
- `node test/checklist_translation.test.js`
- `node test/full_markdown_editing.test.js`
- `node test/instructions_test.js`
- `node test/repo_context_test.js`
- `node test/markdownEditor.test.js`
- `node test/structural_checklist_editing.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68580691197c8323874182f181b8e7b4