### PR TITLE
Add pre-save markdown validation

### DIFF
--- a/markdownFileEditor.js
+++ b/markdownFileEditor.js
@@ -42,7 +42,13 @@ function loadTree(filePath) {
 
 function writeTree(filePath, tree) {
   const content = serializeMarkdownTree(tree);
-  validator.validateMarkdownSyntax(content, filePath);
+  const check = validator.validateMarkdownSyntax(content, filePath);
+  if (!check.valid) {
+    console.error(
+      `[writeTree] ${check.message} at line ${check.line} in '${path.basename(filePath)}'`
+    );
+    return { updated: false, message: 'validation failed', backupPath: null };
+  }
   const backup = mdEditor.createBackup(filePath);
   fs.writeFileSync(filePath, content, 'utf-8');
   return { updated: true, message: 'file updated', backupPath: backup };

--- a/memory.js
+++ b/memory.js
@@ -7,6 +7,7 @@ const indexManager = require('./indexManager');
 const rootConfig = require('./rootConfig');
 const mdEditor = require('./markdownEditor');
 const fileEditor = require('./markdownFileEditor');
+const validator = require('./markdownValidator');
 const {
   parseMarkdownStructure,
   mergeMarkdownTrees,
@@ -53,6 +54,17 @@ function writeFileSafe(filePath, data) {
   try {
     ensureDir(filePath);
     if (filePath.toLowerCase().endsWith('.md')) {
+      const check = validator.validateMarkdownSyntax(data, filePath);
+      if (!check.valid) {
+        const backup = mdEditor.createBackup(filePath);
+        console.error(
+          `[writeFileSafe] ${check.message} at line ${check.line} in '${path.basename(filePath)}'`
+        );
+        if (backup) {
+          console.error(`[writeFileSafe] You can restore from: ${backup}`);
+        }
+        return;
+      }
       mdEditor.createBackup(filePath);
     }
     fs.writeFileSync(filePath, data, 'utf-8');

--- a/test/markdown_validation.test.js
+++ b/test/markdown_validation.test.js
@@ -1,0 +1,42 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const mdEditor = require('../markdownEditor');
+
+const tmpDir = path.join(__dirname, 'tmp_validate');
+if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir);
+
+function read(p){return fs.readFileSync(p,'utf-8');}
+
+(async function run(){
+  // 1. mismatched list levels
+  const f1 = path.join(tmpDir,'bad_list.md');
+  fs.writeFileSync(f1, '# T\n\n## Tasks\n- [ ] Main\n   - [ ] Sub');
+  const r1 = mdEditor.markChecklistItem(f1, 'Tasks', 'Main', true);
+  assert.strictEqual(r1, false);
+  assert.ok(read(f1).includes('- [ ] Main')); // unchanged
+
+  // 2. unclosed code block
+  const f2 = path.join(tmpDir,'code.md');
+  fs.writeFileSync(f2, '# T');
+  const r2 = mdEditor.insertAtAnchor({filePath:f2, content:'```js\nconsole.log(1)', heading:'T', level:1});
+  assert.strictEqual(r2, false);
+  assert.strictEqual(read(f2).trim(), '# T');
+
+  // 3. corrupted update rolled back
+  const f3 = path.join(tmpDir,'corrupt.md');
+  fs.writeFileSync(f3, '# T\ntext');
+  const before = read(f3);
+  const r3 = mdEditor.insertSection(f3, 'T', ['```']);
+  assert.strictEqual(r3, false);
+  assert.strictEqual(read(f3), before);
+
+  // 4. valid update
+  const f4 = path.join(tmpDir,'good.md');
+  fs.writeFileSync(f4, '# T\n\n## S\n- [ ] a');
+  const r4 = mdEditor.markChecklistItem(f4, 'S', 'a', true);
+  assert.strictEqual(r4, true);
+  assert.ok(read(f4).includes('- [x] a'));
+
+  console.log('markdown validation tests passed');
+})();


### PR DESCRIPTION
## Summary
- enhance markdown validation to detect headers, lists, and code fences
- integrate validation in markdown editors and save helpers
- validate instruction file updates
- test markdown validation scenarios

## Testing
- `for f in test/*.test.js; do echo "Running $f"; node $f || break; done`

------
https://chatgpt.com/codex/tasks/task_e_68581d3e3db0832385917e0ad4f12332