### PR TITLE
Enhance markdown validation

### DIFF
--- a/markdownValidator.js
+++ b/markdownValidator.js
@@ -33,6 +33,30 @@ function validateMarkdownSyntax(content, filePath) {
       return { valid: false, line: i + 1, message: 'Invalid header format' };
     }
 
+    if (/^\s*\[[ xX]\]/.test(t)) {
+      return {
+        valid: false,
+        line: i + 1,
+        message: "Invalid list item: missing '-' or '*'"
+      };
+    }
+
+    if (/^[-*]\s*\[[ xX]\](?!\s)/.test(t)) {
+      return {
+        valid: false,
+        line: i + 1,
+        message: 'Checkbox format broken: use "- [ ] text"'
+      };
+    }
+
+    if (/^[-*][^\s\[]/.test(t)) {
+      return {
+        valid: false,
+        line: i + 1,
+        message: 'Invalid list item: missing space after bullet'
+      };
+    }
+
     if (/^[-*]\s*\[/.test(t) && !/^[-*]\s+\[[ xX]\]\s+.+/.test(t)) {
       return { valid: false, line: i + 1, message: 'Malformed checklist item' };
     }

--- a/memory.js
+++ b/memory.js
@@ -50,7 +50,7 @@ function ensureDir(filePath) {
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
 }
 
-function writeFileSafe(filePath, data) {
+function writeFileSafe(filePath, data, force = false) {
   try {
     ensureDir(filePath);
     if (filePath.toLowerCase().endsWith('.md')) {
@@ -63,7 +63,7 @@ function writeFileSafe(filePath, data) {
         if (backup) {
           console.error(`[writeFileSafe] You can restore from: ${backup}`);
         }
-        return;
+        if (!force) return;
       }
       mdEditor.createBackup(filePath);
     }

--- a/test/markdown_validation.test.js
+++ b/test/markdown_validation.test.js
@@ -38,5 +38,18 @@ function read(p){return fs.readFileSync(p,'utf-8');}
   assert.strictEqual(r4, true);
   assert.ok(read(f4).includes('- [x] a'));
 
+  // 5. force write on invalid content
+  const f5 = path.join(tmpDir, 'force.md');
+  fs.writeFileSync(f5, 'Intro\n<!--s-->\nold\n<!--e-->');
+  const r5 = mdEditor.updateMarkdownFile({
+    filePath: f5,
+    startMarker: '<!--s-->',
+    endMarker: '<!--e-->',
+    newContent: '[ ] broken',
+    force: true
+  });
+  assert.strictEqual(r5, true);
+  assert.ok(read(f5).includes('[ ] broken'));
+
   console.log('markdown validation tests passed');
 })();


### PR DESCRIPTION
## Summary
- strengthen markdown syntax checks for lists and checkboxes
- add writeLines helper with `force` option in markdownEditor
- support force-save in updateMarkdownFile, insertSection, insertAtAnchor and deduplicateMarkdown
- allow writeFileSafe to optionally ignore validation errors
- test forced saves with invalid markdown

## Testing
- `for f in test/*test.js; do echo "running $f"; node $f || break; done`

------
https://chatgpt.com/codex/tasks/task_e_68582bc78638832395d583487a473483