### PR TITLE
Extend markdown handling beyond instructions

### DIFF
--- a/indexManager.js
+++ b/indexManager.js
@@ -77,7 +77,10 @@ function generateTitleFromPath(p) {
     .replace(/\b\w/g, l => l.toUpperCase());
 }
 
+const { detectMarkdownCategory } = require('./markdownCategory');
+
 function inferTypeFromPath(p) {
+  if (p.endsWith('.md')) return detectMarkdownCategory(p);
   if (p.includes('plan')) return 'plan';
   if (p.includes('profile')) return 'profile';
   if (p.includes('lesson')) return 'lesson';

--- a/markdownCategory.js
+++ b/markdownCategory.js
@@ -1,0 +1,12 @@
+const path = require('path');
+function detectMarkdownCategory(p){
+  const name = path.basename(p).toLowerCase();
+  if (name.includes('instruction')) return 'instruction';
+  if (name.includes('checklist')) return 'checklist';
+  if (name.includes('plan')) return 'plan';
+  if (name.includes('profile')) return 'profile';
+  if (name.includes('lesson')) return 'lesson';
+  if (name.includes('note')) return 'note';
+  return 'markdown';
+}
+module.exports = { detectMarkdownCategory };

--- a/memory.js
+++ b/memory.js
@@ -505,9 +505,13 @@ function extractToken(req) {
   return null;
 }
 
+const { detectMarkdownCategory } = require('./markdownCategory');
+
 function categorizeMemoryFile(name) {
   const lower = name.toLowerCase();
   const ext = path.extname(lower);
+
+  if (ext === '.md') return detectMarkdownCategory(name);
 
   if (lower === 'plan.md' || lower.endsWith('plan.md')) return 'plan';
   if (lower.includes('lesson')) return 'lesson';
@@ -515,11 +519,13 @@ function categorizeMemoryFile(name) {
   if (lower.includes('context')) return 'context';
   if (lower.includes('practice')) return 'practice';
 
-  if (['.md', '.txt', '.json'].includes(ext)) return 'lesson';
-  if (['.js', '.ts', '.jsx', '.tsx', '.py', '.java', '.html', '.css', '.c', '.cpp'].includes(ext))
+  if (['.txt', '.json'].includes(ext)) return 'lesson';
+  if (
+    ['.js', '.ts', '.jsx', '.tsx', '.py', '.java', '.html', '.css', '.c', '.cpp'].includes(ext)
+  )
     return 'project';
   if (['.png', '.jpg', '.jpeg', '.svg', '.gif'].includes(ext)) return 'project';
-  
+
   return 'memory';
 }
 

--- a/memory/plan_checklist.md
+++ b/memory/plan_checklist.md
@@ -1,12 +1,12 @@
 # Plan Checklist
-- [ ] Пример задачи
-- [x] Не затирать index.json при обновлении
-- [x] Учитывать существующие записи при записи новых уроков
-- [x] Не затирать plan.md при сохранении урока
-- [x] Механизм восстановления контекста по index.json
-- [x] Отладочный режим для тестов
-- [x] Инструкция с поддержкой версий и переключений
-- [ ] 📌 Реализовать двухуровневую систему хранения инструкций (в процессе)
-  - Глобальные инструкции (в плагине, только для чтения)
-  - Индивидуальные инструкции (в репозитории ученика, с версионностью)
-  - Поддержка резервного режима, команд и истории изменений
+- [ ] Example task
+- [x] Do not overwrite index.json when updating
+- [x] Preserve existing records when saving new lessons
+- [x] Do not overwrite plan.md when saving a lesson
+- [x] Context restoration via index.json
+- [x] Debug mode for tests
+- [x] Versioned instructions with switching
+- [ ] 📌 Implement two-level instruction storage system (in progress)
+  - Global instructions (in plugin, read-only)
+  - Individual instructions (in student repository with versioning)
+  - Support backup mode, commands and change history


### PR DESCRIPTION
## Summary
- add `markdownCategory` utility to categorize markdown files
- use new category detection in memory and index manager
- support generic markdown updates in instructions manager
- translate `memory/plan_checklist.md` to English

## Testing
- `node test/markdownEditor.test.js`
- `node test/markdown_update_test.js`
- `node test/markdown_validation.test.js`
- `node test/markdown_merge_engine.test.js`
- `node test/markdown_file_editor.test.js`
- `node test/markdown_anchor_insert.test.js`
- `node test/checklist_translation.test.js`
- `node test/markdown_deduplication.test.js`
- `node test/structural_checklist_editing.test.js`
- `node test/full_markdown_editing.test.js`
- `node test/repo_context_test.js`
- `node test/instructions_test.js`


------
https://chatgpt.com/codex/tasks/task_e_685844f8cc488323b67a52a9e56db156