### PR TITLE
Implement centralized error logging

### DIFF
--- a/githubClient.js
+++ b/githubClient.js
@@ -1,5 +1,6 @@
 
 const axios = require('axios');
+const { logError } = require('./utils/errorHandler');
 
 function normalizeRepo(repo) {
   if (!repo) return repo;
@@ -14,6 +15,7 @@ exports.validateToken = async function (token) {
     });
     return { valid: true, user: res.data.login };
   } catch (e) {
+    logError('validateToken', e);
     return { valid: false, error: e.message };
   }
 };
@@ -26,6 +28,7 @@ exports.repoExists = async function (token, repo) {
     });
     return res.status === 200;
   } catch (e) {
+    logError('repoExists', e);
     return false;
   }
 };

--- a/index.js
+++ b/index.js
@@ -15,13 +15,13 @@ app.post('/list', async (req, res) => {
   try {
     const { repo, token, path: dirPath } = req.body;
     if (!repo || !token || !dirPath) {
-      return res.status(400).json({ error: 'Missing repo, token, or path' });
+      return res.status(400).json({ status: 'error', message: 'Missing repo, token, or path' });
     }
 
     const fileList = await listMemoryFiles(repo, token, dirPath);
     return res.json({ status: 'success', files: fileList });
   } catch (error) {
-    return res.status(500).json({ error: error.message });
+    return res.status(500).json({ status: 'error', message: error.message });
   }
 });
 
@@ -37,7 +37,7 @@ app.get('/', (req, res) => {
 app.get('/debug/index', (req, res) => {
   const indexPath = path.join(__dirname, 'memory', 'index.json');
   if (!fs.existsSync(indexPath)) {
-    return res.status(404).send('index.json not found');
+    return res.status(404).json({ status: 'error', message: 'index.json not found' });
   }
   const data = fs.readFileSync(indexPath, 'utf-8');
   res.type('text/plain').send(data);

--- a/indexManager.js
+++ b/indexManager.js
@@ -10,6 +10,7 @@ const {
   generateTitleFromPath,
   inferTypeFromPath
 } = require('./utils/fileUtils');
+const { logError } = require('./utils/errorHandler');
 
 const indexPath = path.join(__dirname, 'memory', 'index.json');
 let indexData = null;
@@ -36,7 +37,7 @@ async function githubWriteFileSafe(token, repo, relPath, data, message, attempts
       if (process.env.DEBUG) console.log(`[indexManager] pushed ${relPath}`);
       return;
     } catch (e) {
-      console.error(`[indexManager] GitHub write attempt ${i} failed`, e.message);
+      logError(`indexManager write attempt ${i}`, e);
       if (i === attempts) throw e;
     }
   }
@@ -119,7 +120,7 @@ async function saveIndex(token, repo, userId) {
       const remote = JSON.parse(remoteRaw);
       remoteData = remote;
     } catch (e) {
-      if (e.response?.status !== 404) console.error('[indexManager] GitHub read error', e.message);
+      if (e.response?.status !== 404) logError('indexManager GitHub read', e);
     }
   }
 
@@ -131,7 +132,7 @@ async function saveIndex(token, repo, userId) {
     fs.writeFileSync(indexPath, JSON.stringify(indexData, null, 2), 'utf-8');
     if (process.env.DEBUG) console.log('[indexManager] index saved locally');
   } catch (e) {
-    console.error('[indexManager] local write error', e.message);
+    logError('indexManager local write', e);
   }
 
   if (finalRepo && finalToken) {
@@ -145,7 +146,7 @@ async function saveIndex(token, repo, userId) {
       );
       if (process.env.DEBUG) console.log('[indexManager] \u2714 index.json pushed');
     } catch (e) {
-      console.error('[indexManager] failed to push index to GitHub', e.message);
+      logError('indexManager push index', e);
     }
   }
 }

--- a/instructionsManager.js
+++ b/instructionsManager.js
@@ -8,6 +8,7 @@ const mdEditor = require('./markdownEditor');
 const validator = require('./markdownValidator');
 const mdFileEditor = require('./markdownFileEditor');
 const { ensureDir, normalizeMemoryPath } = require('./utils/fileUtils');
+const { logError } = require('./utils/errorHandler');
 
 const git = simpleGit();
 const SKIP_GIT = process.env.NO_GIT === "true";
@@ -54,8 +55,9 @@ async function loadFromGitHub(repo = DEFAULT_REPO, token, file = DEFAULT_FILE, v
   const dest = versionPath(version);
   const check = validator.validateMarkdownSyntax(content, dest);
   if (!check.valid) {
-    console.error(
-      `[loadFromGitHub] ${check.message} at line ${check.line} in '${path.basename(dest)}'`
+    logError(
+      'loadFromGitHub',
+      new Error(`${check.message} at line ${check.line} in '${path.basename(dest)}'`)
     );
     return '';
   }
@@ -157,8 +159,9 @@ async function edit(version, newContent, opts = {}) {
   if (!devMode) saveHistory(version);
   const check = validator.validateMarkdownSyntax(newContent, dest);
   if (!check.valid) {
-    console.error(
-      `[edit] ${check.message} at line ${check.line} in '${path.basename(dest)}'`
+    logError(
+      'edit instructions',
+      new Error(`${check.message} at line ${check.line} in '${path.basename(dest)}'`)
     );
     return null;
   }
@@ -191,8 +194,9 @@ async function updateMarkdownFile(relPath, newContent, opts = {}) {
   const oldContent = fs.existsSync(abs) ? fs.readFileSync(abs, 'utf-8') : '';
   const check = validator.validateMarkdownSyntax(newContent, dest);
   if (!check.valid) {
-    console.error(
-      `[updateMarkdownFile] ${check.message} at line ${check.line} in '${path.basename(dest)}'`
+    logError(
+      'updateMarkdownFile',
+      new Error(`${check.message} at line ${check.line} in '${path.basename(dest)}'`)
     );
     return null;
   }

--- a/utils/errorHandler.js
+++ b/utils/errorHandler.js
@@ -1,0 +1,16 @@
+function logError(context, error) {
+  const msg = error && error.message ? error.message : error;
+  if (process.env.DEBUG) {
+    console.error(`[${context}]`, msg, error && error.stack);
+  } else {
+    console.error(`[${context}]`, msg);
+  }
+}
+
+function asyncHandler(fn) {
+  return function(req, res, next) {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+}
+
+module.exports = { logError, asyncHandler };

--- a/versioning.js
+++ b/versioning.js
@@ -7,7 +7,7 @@ exports.commitInstructions = async (req, res) => {
     await instructions.edit(version, content);
     res.json({ status: 'success', version });
   } catch (e) {
-    res.status(500).json({ error: e.message });
+    res.status(500).json({ status: 'error', message: e.message });
   }
 };
 
@@ -19,7 +19,7 @@ exports.rollbackInstructions = async (req, res) => {
     await instructions.rollback(version, file);
     res.json({ status: 'success', restored: file });
   } catch (e) {
-    res.status(500).json({ error: e.message });
+    res.status(500).json({ status: 'error', message: e.message });
   }
 };
 


### PR DESCRIPTION
## Summary
- add `utils/errorHandler.js` for reusable logError and async handler
- log errors with `logError` in memory routes, index manager, instructions manager and GitHub client
- return JSON error objects for all Express endpoints

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_685859d534d483239f5a820a329add17