### PR TITLE
Add unified storage module with fallback

### DIFF
--- a/context.js
+++ b/context.js
@@ -1,8 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const github = require('./utils/githubClient');
-const tokenStore = require('./utils/tokenStore');
-const memoryConfig = require('./utils/memoryConfig');
+const { readMemory } = require('./core/storage');
 
 /**
  * Helper to read a file either from GitHub or local disk.
@@ -15,23 +13,7 @@ const memoryConfig = require('./utils/memoryConfig');
  */
 async function readFile(filePath, opts = {}) {
   const { userId, repo, token } = opts;
-  const normalized = filePath.replace(/^\/+/, '');
-  const finalRepo = repo || memoryConfig.getRepoUrl(userId);
-  const finalToken = token || tokenStore.getToken(userId);
-
-  if (finalRepo && finalToken) {
-    try {
-      return await github.readFile(finalToken, finalRepo, normalized);
-    } catch (e) {
-      console.error(`[readFile] GitHub fetch failed for ${normalized}`, e.message);
-    }
-  }
-
-  const abs = path.join(__dirname, normalized);
-  if (fs.existsSync(abs)) {
-    return fs.readFileSync(abs, 'utf-8');
-  }
-  throw new Error(`File not found: ${normalized}`);
+  return readMemory(userId, repo, token, filePath.replace(/^\/+/, ''));
 }
 
 /**

--- a/core/indexManager.js
+++ b/core/indexManager.js
@@ -152,22 +152,8 @@ async function saveIndex(token, repo, userId) {
 }
 
 async function saveMemoryWithIndex(userId, repo, token, filename, content) {
-  const finalRepo = repo || memoryConfig.getRepoUrl(userId);
-  const finalToken = token || tokenStore.getToken(userId);
-  if (!finalRepo || !finalToken) {
-    throw new Error('Missing repo or token');
-  }
-  const normalized = normalizeMemoryPath(filename);
-  await githubWriteFileSafe(finalToken, finalRepo, normalized, content, `update ${filename}`);
-  await addOrUpdateEntry({
-    path: normalized,
-    title: generateTitleFromPath(normalized),
-    type: inferTypeFromPath(normalized),
-    lastModified: new Date().toISOString()
-  });
-  await saveIndex(finalToken, finalRepo, userId);
-  console.log(`[Memory] Saved and indexed: ${normalized}`);
-  return normalized;
+  const storage = require('./storage');
+  return storage.saveMemoryWithIndex(userId, repo, token, filename, content);
 }
 
 module.exports = {

--- a/core/storage.js
+++ b/core/storage.js
@@ -1,0 +1,69 @@
+const fs = require('fs');
+const path = require('path');
+const github = require('../utils/githubClient');
+const tokenStore = require('../utils/tokenStore');
+const memoryConfig = require('../utils/memoryConfig');
+const indexManager = require('./indexManager');
+const { githubWriteFileSafe } = require('./memoryOperations');
+const {
+  ensureDir,
+  normalizeMemoryPath,
+} = require('../utils/fileUtils');
+
+async function readMemory(userId, repo, token, filename) {
+  const normalized = normalizeMemoryPath(filename);
+  const finalRepo = repo || memoryConfig.getRepoUrl(userId);
+  const finalToken = token || tokenStore.getToken(userId);
+
+  if (finalRepo && finalToken) {
+    try {
+      return await github.readFile(finalToken, finalRepo, normalized);
+    } catch (e) {
+      console.error(`[storage.readMemory] GitHub read failed for ${normalized}`, e.message);
+    }
+  }
+
+  const localPath = path.join(__dirname, '..', normalized);
+  if (fs.existsSync(localPath)) {
+    return fs.readFileSync(localPath, 'utf-8');
+  }
+  throw new Error(`File not found: ${normalized}`);
+}
+
+async function saveMemory(userId, repo, token, filename, content) {
+  const normalized = normalizeMemoryPath(filename);
+  const finalRepo = repo || memoryConfig.getRepoUrl(userId);
+  const finalToken = token || tokenStore.getToken(userId);
+  const localPath = path.join(__dirname, '..', normalized);
+  ensureDir(localPath);
+  fs.writeFileSync(localPath, content, 'utf-8');
+
+  if (finalRepo && finalToken) {
+    try {
+      await githubWriteFileSafe(finalToken, finalRepo, normalized, content, `update ${filename}`);
+    } catch (e) {
+      console.error(`[storage.saveMemory] GitHub write failed for ${normalized}`, e.message);
+    }
+  }
+  return normalized;
+}
+
+async function saveMemoryWithIndex(userId, repo, token, filename, content) {
+  const savedPath = await saveMemory(userId, repo, token, filename, content);
+  await indexManager.addOrUpdateEntry({
+    path: savedPath,
+    title: indexManager.generateTitleFromPath(savedPath),
+    type: indexManager.inferTypeFromPath(savedPath),
+    lastModified: new Date().toISOString(),
+  });
+  await indexManager.saveIndex(token, repo, userId);
+  return savedPath;
+}
+
+module.exports = {
+  readMemory,
+  saveMemory,
+  saveMemoryWithIndex,
+  addOrUpdateEntry: indexManager.addOrUpdateEntry,
+  saveIndex: indexManager.saveIndex,
+};

--- a/memoryWithIndex.js
+++ b/memoryWithIndex.js
@@ -1,23 +1,5 @@
-const { githubWriteFileSafe } = require('./core/memoryOperations');
-const { addOrUpdateEntry, saveIndex } = require('./core/indexManager');
-const { generateTitleFromPath, inferTypeFromPath } = require('./utils/fileUtils');
-
-async function saveMemoryWithIndex(userId, repo, token, filename, content) {
-  // Step 1: Save file to GitHub
-  await githubWriteFileSafe(token, repo, filename, content, `update ${filename}`);
-
-  // Step 2: Add entry to index
-  addOrUpdateEntry({
-    path: filename,
-    title: generateTitleFromPath(filename),
-    type: inferTypeFromPath(filename),
-    lastModified: new Date().toISOString()
-  });
-
-  // Step 3: Save updated index.json
-  await saveIndex(token, repo);
-}
+const { saveMemoryWithIndex } = require('./core/storage');
 
 module.exports = {
-  saveMemoryWithIndex
+  saveMemoryWithIndex,
 };


### PR DESCRIPTION
## Summary
- add new `core/storage.js` for unified read/save operations with GitHub fallback
- update `memoryWithIndex.js` to use the storage module
- route indexManager `saveMemoryWithIndex` through storage
- use storage helper in `context.js`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685860eb47d48323b5092f75942f2360