### PR TITLE
Fix markdown merging for saveMemory

### DIFF
--- a/routes/memoryRoutes.js
+++ b/routes/memoryRoutes.js
@@ -62,7 +62,7 @@ async function saveMemory(req, res) {
       if (existing) {
         const baseTree = parseMarkdownStructure(existing);
         const newTree = parseMarkdownStructure(content);
-        const merged = mergeMarkdownTrees(baseTree, newTree);
+        const merged = mergeMarkdownTrees(baseTree, newTree, { dedupe: true });
         finalContent = serializeMarkdownTree(merged);
       }
     } catch (e) {


### PR DESCRIPTION
## Summary
- avoid duplicating checklist entries when saving Markdown content

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685879b7e1e08323ac699b089c9ca40c