### PR TITLE
Enable JSON memory file reading

### DIFF
--- a/core/storage.js
+++ b/core/storage.js
@@ -8,25 +8,42 @@ const {
   ensureDir,
   normalizeMemoryPath,
 } = require('../utils/fileUtils');
+const { logError } = require('../utils/errorHandler');
 
-async function readMemory(userId, repo, token, filename) {
+async function readMemory(userId, repo, token, filename, opts = {}) {
   const normalized = normalizeMemoryPath(filename);
+  const parseJson = opts.parseJson || false;
   const finalRepo = repo || memoryConfig.getRepoUrl(userId);
   const finalToken = token || tokenStore.getToken(userId);
 
+  let content = null;
+
   if (finalRepo && finalToken) {
     try {
-      return await github.readFile(finalToken, finalRepo, normalized);
+      content = await github.readFile(finalToken, finalRepo, normalized);
     } catch (e) {
       console.error(`[storage.readMemory] GitHub read failed for ${normalized}`, e.message);
     }
   }
 
-  const localPath = path.join(__dirname, '..', normalized);
-  if (fs.existsSync(localPath)) {
-    return fs.readFileSync(localPath, 'utf-8');
+  if (!content) {
+    const localPath = path.join(__dirname, '..', normalized);
+    if (fs.existsSync(localPath)) {
+      content = fs.readFileSync(localPath, 'utf-8');
+    } else {
+      throw new Error(`File not found: ${normalized}`);
+    }
   }
-  throw new Error(`File not found: ${normalized}`);
+
+  if (parseJson && normalized.endsWith('.json')) {
+    try {
+      return JSON.parse(content);
+    } catch (e) {
+      console.error(`[storage.readMemory] failed to parse JSON ${normalized}`, e.message);
+      throw e;
+    }
+  }
+  return content;
 }
 
 async function saveMemory(userId, repo, token, filename, content) {
@@ -65,10 +82,31 @@ async function saveMemoryWithIndex(userId, repo, token, filename, content) {
   return savedPath;
 }
 
+async function getFile(userId, repo, token, filename) {
+  const isJson = filename.trim().toLowerCase().endsWith('.json');
+  try {
+    const content = await readMemory(userId, repo, token, filename);
+    if (isJson) {
+      try {
+        const json = JSON.parse(content);
+        return { content, json };
+      } catch (e) {
+        logError('getFile parse json', e);
+        return { content, json: null };
+      }
+    }
+    return { content };
+  } catch (e) {
+    logError('getFile', e);
+    throw e;
+  }
+}
+
 module.exports = {
   readMemory,
   saveMemory,
   saveMemoryWithIndex,
+  getFile,
   addOrUpdateEntry: indexManager.addOrUpdateEntry,
   saveIndex: indexManager.saveIndex,
 };

--- a/routes/memoryRoutes.js
+++ b/routes/memoryRoutes.js
@@ -133,6 +133,7 @@ async function readMemory(req, res) {
 
   const normalizedFilename = normalizeMemoryPath(filename);
   const filePath = path.join(__dirname, '..', normalizedFilename);
+  const isJson = normalizedFilename.endsWith('.json');
 
   console.log(`[read] repo=${effectiveRepo || 'local'} file=${normalizedFilename}`);
 
@@ -141,6 +142,15 @@ async function readMemory(req, res) {
     try {
       const content = await github.readFile(effectiveToken, effectiveRepo, normalizedFilename);
       console.log(`[read] success remote ${normalizedFilename}`);
+      if (isJson) {
+        try {
+          const json = JSON.parse(content);
+          return res.json({ status: 'success', content, json });
+        } catch (e) {
+          logError('readMemory parse json', e);
+          return res.status(500).json({ status: 'error', message: 'Failed to parse JSON' });
+        }
+      }
       return res.json({ status: 'success', content });
     } catch (e) {
       console.error('[read] error remote', e.message);
@@ -154,6 +164,15 @@ async function readMemory(req, res) {
   }
   const content = fs.readFileSync(filePath, 'utf-8');
   console.log(`[read] success local ${normalizedFilename}`);
+  if (isJson) {
+    try {
+      const json = JSON.parse(content);
+      return res.json({ status: 'success', content, json });
+    } catch (e) {
+      logError('readMemory parse json', e);
+      return res.status(500).json({ status: 'error', message: 'Failed to parse JSON' });
+    }
+  }
   res.json({ status: 'success', content });
 }
 


### PR DESCRIPTION
## Summary
- handle `.json` files when reading memory
- add helper to return parsed JSON for memory files
- parse JSON in the read route with error logging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68587c2cdf0883238ca313cb77016422