### PR TITLE
Add memory path logging

### DIFF
--- a/logic/storage.js
+++ b/logic/storage.js
@@ -16,6 +16,11 @@ async function read_memory(user_id, repo, token, filename, opts = {}) {
   const finalRepo = repo || memory_config.getRepoUrl(user_id);
   const finalToken = token || token_store.getToken(user_id);
 
+  const masked = finalToken ? `${finalToken.slice(0, 4)}...` : 'null';
+  console.log('[read_memory] repo:', finalRepo);
+  console.log('[read_memory] token:', masked);
+  console.log('[read_memory] file:', normalized);
+
   let content = null;
 
   if (finalRepo && finalToken) {
@@ -50,6 +55,10 @@ async function save_memory(user_id, repo, token, filename, content) {
   const normalized = normalize_memory_path(filename);
   const finalRepo = repo || memory_config.getRepoUrl(user_id);
   const finalToken = token || token_store.getToken(user_id);
+  const masked = finalToken ? `${finalToken.slice(0, 4)}...` : 'null';
+  console.log('[save_memory] repo:', finalRepo);
+  console.log('[save_memory] token:', masked);
+  console.log('[save_memory] file:', normalized);
   const localPath = path.join(__dirname, '..', normalized);
   ensure_dir(localPath);
   fs.writeFileSync(localPath, content, 'utf-8');

--- a/tools/file_utils.js
+++ b/tools/file_utils.js
@@ -46,6 +46,8 @@ function normalize_memory_path(p) {
   if (!p) return 'memory/';
   let rel = p.replace(/\\+/g, '/');
   rel = path.posix.normalize(rel).replace(/^(\.\/)+/, '').replace(/^\/+/, '');
+  // FIXME: '..' segments remain after normalization, allowing paths outside
+  // the memory directory. Remove '..' parts to prevent traversal.
   while (rel.startsWith('memory/')) {
     rel = rel.slice('memory/'.length);
   }

--- a/tools/github_client.js
+++ b/tools/github_client.js
@@ -37,6 +37,11 @@ exports.repoExists = async function (token, repo) {
 exports.readFile = async function(token, repo, filePath) {
   const normalized = normalizeRepo(repo);
   const url = `https://api.github.com/repos/${normalized}/contents/${encodeURIComponent(filePath)}`;
+  const masked = token ? `${token.slice(0, 4)}...` : 'null';
+  console.log('[readFile] Repo:', normalized);
+  console.log('[readFile] Token:', masked);
+  console.log('[readFile] File:', filePath);
+  console.log('[readFile] URL:', url);
   const res = await axios.get(url, { headers: { Authorization: `token ${token}` } });
   return Buffer.from(res.data.content, 'base64').toString('utf-8');
 };
@@ -44,6 +49,11 @@ exports.readFile = async function(token, repo, filePath) {
 exports.writeFile = async function(token, repo, filePath, content, message) {
   const normalized = normalizeRepo(repo);
   const url = `https://api.github.com/repos/${normalized}/contents/${encodeURIComponent(filePath)}`;
+  const masked = token ? `${token.slice(0, 4)}...` : 'null';
+  console.log('[writeFile] Repo:', normalized);
+  console.log('[writeFile] Token:', masked);
+  console.log('[writeFile] File:', filePath);
+  console.log('[writeFile] URL:', url);
   let sha = undefined;
   try {
     const res = await axios.get(url, { headers: { Authorization: `token ${token}` } });


### PR DESCRIPTION
## Summary
- log repo and token in storage
- log final GitHub URLs in github_client
- document path traversal issue in `normalize_memory_path`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a9ba81de48323a376d6dfdc4c9505