### PR TITLE
Fix export in memory_with_index

### DIFF
--- a/memory_with_index.js
+++ b/memory_with_index.js
@@ -1,5 +1,5 @@
 // Экспорт функции сохранения с обновлением индекса
-const { saveMemoryWithIndex: save_memory_with_index } = require('./logic/storage');
+const { save_memory_with_index } = require('./logic/storage');
 
 module.exports = {
   // Функция сохраняет файл и обновляет индекс


### PR DESCRIPTION
## Summary
- correct the exported symbol in `memory_with_index.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685aa2a698d48323843fcb248dc3dafe