### PR TITLE
Add debug logging for memory operations

### DIFF
--- a/memory.js
+++ b/memory.js
@@ -3,6 +3,7 @@ const { restore_context } = require('./context');
 const memory_config = require('./tools/memory_config');
 const token_store = require('./tools/token_store');
 const { normalize_memory_path } = require('./tools/file_utils');
+const logger = require('./utils/logger');
 
 function normalize_repo(repo) {
   if (!repo) return repo;
@@ -16,7 +17,7 @@ async function readMemory(repo, token, filename) {
   const masked_token = final_token ? `${final_token.slice(0, 4)}...` : 'null';
   const normalized_file = normalize_memory_path(filename);
 
-  console.log('[readMemory] Called with:', {
+  logger.info('[readMemory] called', {
     repo: repo || null,
     token: masked_token,
     filename,
@@ -24,15 +25,15 @@ async function readMemory(repo, token, filename) {
 
   if (final_repo && final_token) {
     const url = `https://api.github.com/repos/${normalize_repo(final_repo)}/contents/${encodeURIComponent(normalized_file)}`;
-    console.log('[readMemory] Sending GET request to:', url);
+    logger.debug('[readMemory] request url', url);
   }
 
   try {
     const content = await read_memory(null, repo, token, filename);
-    console.log('[readMemory] Response: success');
+    logger.info('[readMemory] success');
     return content;
   } catch (e) {
-    console.error('[readMemory] Error:', e.message);
+    logger.error('[readMemory] error', e.message);
     throw e;
   }
 }
@@ -43,7 +44,7 @@ async function saveMemory(repo, token, filename, content) {
   const masked_token = final_token ? `${final_token.slice(0, 4)}...` : 'null';
   const normalized_file = normalize_memory_path(filename);
 
-  console.log('[saveMemory] Called with:', {
+  logger.info('[saveMemory] called', {
     repo: repo || null,
     token: masked_token,
     filename,
@@ -52,15 +53,15 @@ async function saveMemory(repo, token, filename, content) {
 
   if (final_repo && final_token) {
     const url = `https://api.github.com/repos/${normalize_repo(final_repo)}/contents/${encodeURIComponent(normalized_file)}`;
-    console.log('[saveMemory] Sending PUT request to:', url);
+    logger.debug('[saveMemory] request url', url);
   }
 
   try {
     const result = await save_memory(null, repo, token, filename, content);
-    console.log('[saveMemory] Response: success');
+    logger.info('[saveMemory] success');
     return result;
   } catch (e) {
-    console.error('[saveMemory] Error:', e.message);
+    logger.error('[saveMemory] error', e.message);
     throw e;
   }
 }
@@ -68,14 +69,14 @@ async function saveMemory(repo, token, filename, content) {
 function setMemoryRepo(token, repo) {
   const user_id = null;
   const masked = token ? `${token.slice(0, 4)}...` : 'null';
-  console.log('[setMemoryRepo] Called with:', { repo, token: masked });
+  logger.info('[setMemoryRepo] called', { repo, token: masked });
 
   try {
     if (token !== undefined) token_store.setToken(user_id, token);
     if (repo !== undefined) memory_config.setRepoUrl(user_id, repo);
-    console.log('[setMemoryRepo] Stored settings');
+    logger.info('[setMemoryRepo] stored settings');
   } catch (e) {
-    console.error('[setMemoryRepo] Error:', e.message);
+    logger.error('[setMemoryRepo] error', e.message);
     throw e;
   }
 }
@@ -85,22 +86,22 @@ async function refreshContextFromMemoryFiles(repo, token) {
   const final_token = token || token_store.getToken(null);
   const masked_token = final_token ? `${final_token.slice(0, 4)}...` : 'null';
 
-  console.log('[refreshContextFromMemoryFiles] Called with:', {
+  logger.info('[refreshContextFromMemoryFiles] called', {
     repo: repo || null,
     token: masked_token,
   });
 
   if (final_repo && final_token) {
     const url = `https://api.github.com/repos/${normalize_repo(final_repo)}/contents/${encodeURIComponent('memory/index.json')}`;
-    console.log('[refreshContextFromMemoryFiles] Sending GET request to:', url);
+    logger.debug('[refreshContextFromMemoryFiles] request url', url);
   }
 
   try {
     const result = await restore_context(false, { userId: null, repo, token });
-    console.log('[refreshContextFromMemoryFiles] Response: success');
+    logger.info('[refreshContextFromMemoryFiles] success');
     return result;
   } catch (e) {
-    console.error('[refreshContextFromMemoryFiles] Error:', e.message);
+    logger.error('[refreshContextFromMemoryFiles] error', e.message);
     throw e;
   }
 }

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+let stream = null;
+
+function setLogFile(path) {
+  if (path) {
+    stream = fs.createWriteStream(path, { flags: 'a' });
+  } else {
+    if (stream) {
+      stream.end();
+    }
+    stream = null;
+  }
+}
+
+function timestamp() {
+  return new Date().toISOString().replace('T', ' ').slice(0, 19);
+}
+
+function log(level, msg, data) {
+  const base = `[${timestamp()}] ${level} ${msg}`;
+  const line = data !== undefined ? `${base} ${typeof data === 'string' ? data : JSON.stringify(data)}` : base;
+  if (stream) {
+    stream.write(line + '\n');
+  } else {
+    if (level === 'ERROR') {
+      console.error(line);
+    } else {
+      console.log(line);
+    }
+  }
+}
+
+module.exports = {
+  setLogFile,
+  info: (msg, data) => log('INFO', msg, data),
+  debug: (msg, data) => log('DEBUG', msg, data),
+  error: (msg, data) => log('ERROR', msg, data),
+};


### PR DESCRIPTION
## Summary
- add simple logger utility with timestamp and log levels
- switch memory helper functions to use the logger

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685aafda39d48323924e8f0f36c9c8d9