### PR TITLE
feat: universal memory file reader

### DIFF
--- a/context.js
+++ b/context.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const { read_memory } = require('./logic/storage');
+const { get_file } = require('./logic/storage');
 const rootConfig = require('./config');
 
 /**
@@ -13,8 +13,17 @@ const rootConfig = require('./config');
  * @returns {Promise<string>} file contents
  */
 async function readFile(filePath, opts = {}) {
-  const { userId, repo, token } = opts;
-  return read_memory(userId, repo, token, filePath.replace(/^\/+/, ''));
+  const { userId, repo, token, source = 'index.json' } = opts;
+  const normalized = filePath.replace(/^\/+/, '');
+  console.log(`[readFile] ${source} -> ${normalized}`);
+  try {
+    const { content } = await get_file(userId, repo, token, normalized);
+    console.log(`[readFile] success ${normalized}`);
+    return content;
+  } catch (e) {
+    console.warn(`[readFile] fail ${normalized}`, e.message);
+    throw e;
+  }
 }
 
 async function loadIndexFile(debug, opts = {}) {

--- a/memory.js
+++ b/memory.js
@@ -1,4 +1,4 @@
-const { read_memory, save_memory } = require('./logic/storage');
+const { read_memory, save_memory, get_file } = require('./logic/storage');
 const { restore_context } = require('./context');
 const memory_config = require('./tools/memory_config');
 const token_store = require('./tools/token_store');
@@ -106,9 +106,28 @@ async function refreshContextFromMemoryFiles(repo, token) {
   }
 }
 
+async function read_memory_file(filename, opts = {}) {
+  const { repo = null, token = null, source = 'chat' } = opts;
+  const normalized = normalize_memory_path(filename);
+  logger.info('[read_memory_file] open', { path: normalized, source });
+  try {
+    const result = await get_file(null, repo, token, normalized);
+    logger.info('[read_memory_file] success', { path: normalized, source });
+    return result.content;
+  } catch (e) {
+    logger.error('[read_memory_file] error', {
+      path: normalized,
+      source,
+      error: e.message,
+    });
+    throw e;
+  }
+}
+
 module.exports = {
   readMemory,
   saveMemory,
   refreshContextFromMemoryFiles,
   setMemoryRepo,
+  read_memory_file,
 };


### PR DESCRIPTION
## Summary
- add `read_memory_file` for generic path access
- update context helper to log and read through new storage getter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ab3bfe738832390737d586075613e