### PR TITLE
Fix Render deployment with health route

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,15 +57,18 @@ app.get('/debug/index', (req, res) => {
 
 // Дополнительные alias-маршруты для совместимости
 
-const PORT = process.env.PORT || 3000;
+const PORT = process.env.PORT || 10000;
 app.listen(PORT, () => {
-  console.log(`Sofia Plugin Server running on port ${PORT}`);
+  console.log(`[START] Sofia Plugin is running on port ${PORT}`);
 });
 
 // Проверка доступности сервера
 app.get('/ping', (req, res) => {
   res.send('pong');
 });
+
+// Health check route for Render
+app.get('/health', (_req, res) => res.send('OK'));
 
 // Автодокументация
 app.get('/docs', (req, res) => {

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,9 @@
+services:
+  - type: web
+    name: sofia-memory-plugin
+    env: node
+    buildCommand: npm install
+    startCommand: node index.js
+    healthCheckPath: /health
+    startTimeout: 120
+


### PR DESCRIPTION
## Summary
- use `process.env.PORT` with a fallback to 10000
- log start message with `[START]` prefix
- add `/health` endpoint
- add Render configuration file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685abc18a2c083238acf9f375cf1da92