### PR TITLE
Implement universal markdown reader

### DIFF
--- a/assets/openapi.yaml
+++ b/assets/openapi.yaml
@@ -44,6 +44,19 @@ paths:
       responses:
         '200':
           description: File contents
+  /readFile:
+    post:
+      summary: Read markdown file
+      operationId: readFile
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReadMemoryRequest'
+      responses:
+        '200':
+          description: File contents
   /memory:
     get:
       summary: Read memory file via query

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -57,6 +57,19 @@ paths:
       responses:
         '200':
           description: File contents
+  /readFile:
+    post:
+      summary: Read markdown file
+      operationId: readFile
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReadMemoryRequest'
+      responses:
+        '200':
+          description: File contents
   /memory:
     get:
       summary: Read memory file via query


### PR DESCRIPTION
## Summary
- add a generic `readMarkdownFile` helper
- expose new `/readFile` route for reading markdowns
- document the endpoint in OpenAPI specs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685afd0d86908323ad5b9bbf9afc4bdc