### PR TITLE
Add safe markdown editing utilities

### DIFF
--- a/tests/markdown_safe_edit.test.js
+++ b/tests/markdown_safe_edit.test.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const { editMarkdownFile, readMarkdownFile } = require('../tools/markdown_safe_edit');
+
+const tmpDir = path.join(__dirname, 'tmp_safe');
+if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir);
+
+async function run() {
+  const file = path.join(tmpDir, 'sample.md');
+  fs.writeFileSync(file, '# Title\n\nText');
+  const orig = readMarkdownFile(file);
+  assert.ok(orig.includes('Title'));
+
+  await editMarkdownFile(file, content => content + '\nMore', { autoConfirm: true });
+  const updated = fs.readFileSync(file, 'utf-8');
+  assert.ok(updated.includes('More'));
+
+  const before = fs.readFileSync(file, 'utf-8');
+  await editMarkdownFile(file, c => c + '\nExtra', { dryRun: true, autoConfirm: true });
+  const after = fs.readFileSync(file, 'utf-8');
+  assert.strictEqual(before, after);
+
+  console.log('markdown safe edit tests passed');
+}
+
+run();

--- a/tools/markdown_safe_edit.js
+++ b/tools/markdown_safe_edit.js
@@ -1,0 +1,89 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const readline = require('readline');
+const { spawnSync } = require('child_process');
+const { createBackup } = require('../logic/markdown_editor');
+
+let original_cache = new Map();
+
+function readMarkdownFile(filepath) {
+  const abs = path.resolve(filepath);
+  let content = '';
+  try {
+    content = fs.readFileSync(abs, 'utf-8');
+  } catch {
+    content = '';
+  }
+  original_cache.set(abs, content);
+  return content;
+}
+
+function lineSimilarity(a, b) {
+  const aSet = new Set(a.split(/\r?\n/));
+  const bSet = new Set(b.split(/\r?\n/));
+  let same = 0;
+  for (const l of aSet) {
+    if (bSet.has(l)) same++;
+  }
+  return bSet.size === 0 && aSet.size === 0 ? 1 : same / Math.max(aSet.size, bSet.size);
+}
+
+function previewDiff(oldTxt, newTxt) {
+  const tmpDir = os.tmpdir();
+  const o = path.join(tmpDir, `orig_${Date.now()}.md`);
+  const n = path.join(tmpDir, `new_${Date.now()}.md`);
+  fs.writeFileSync(o, oldTxt);
+  fs.writeFileSync(n, newTxt);
+  const out = spawnSync('diff', ['-u', o, n], { encoding: 'utf8' });
+  try { fs.unlinkSync(o); } catch {}
+  try { fs.unlinkSync(n); } catch {}
+  return out.stdout || 'No differences';
+}
+
+function ask(question) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise(resolve => rl.question(question, a => { rl.close(); resolve(a); }));
+}
+
+async function editMarkdownFile(filepath, editCallback, opts = {}) {
+  const { dryRun = false, autoConfirm = false } = opts;
+  const original = readMarkdownFile(filepath);
+  const edited = await Promise.resolve(editCallback(original));
+  if (edited === undefined || edited === null) return false;
+  const ratio = lineSimilarity(original, edited);
+  if (ratio < 0.2) {
+    console.warn('[editMarkdownFile] Low similarity between versions');
+  }
+  if (original !== edited) {
+    const diff = previewDiff(original, edited);
+    console.log(diff);
+  } else {
+    return false;
+  }
+  if (dryRun) return false;
+  let confirmed = autoConfirm;
+  if (!confirmed) {
+    const a = await ask('Apply changes? [y/N] ');
+    confirmed = /^y(es)?$/i.test(a.trim());
+  }
+  if (!confirmed) {
+    console.log('Edit cancelled.');
+    return false;
+  }
+  writeMarkdownFile(filepath, edited);
+  return true;
+}
+
+function writeMarkdownFile(filepath, newContent) {
+  const abs = path.resolve(filepath);
+  createBackup(abs);
+  fs.writeFileSync(abs, newContent, 'utf-8');
+  original_cache.delete(abs);
+}
+
+module.exports = {
+  readMarkdownFile,
+  editMarkdownFile,
+  writeMarkdownFile
+};


### PR DESCRIPTION
## Summary
- implement `readMarkdownFile`, `editMarkdownFile`, and `writeMarkdownFile`
- use diff preview and similarity check before applying changes
- test safe markdown editing logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b018e3dc483238f41b261aebc697a