### PR TITLE
Implement adaptive context priority

### DIFF
--- a/logic/index_manager.js
+++ b/logic/index_manager.js
@@ -159,7 +159,15 @@ async function addOrUpdateEntry(entry) {
     indexData[idx] = { ...indexData[idx], ...entry, ...base };
     if (process.env.DEBUG) console.log(`[indexManager] Updated entry ${entry.path}`);
   } else {
-    indexData.push({ ...entry, ...base });
+    indexData.push({
+      context_priority: 'high',
+      last_accessed: new Date().toISOString(),
+      access_count: 0,
+      edit_count: 0,
+      pinned: false,
+      ...entry,
+      ...base,
+    });
     if (process.env.DEBUG) console.log(`[indexManager] Added entry ${entry.path}`);
   }
   await saveIndex();

--- a/logic/storage.js
+++ b/logic/storage.js
@@ -5,6 +5,10 @@ const token_store = require('../tools/token_store');
 const memory_config = require('../tools/memory_config');
 const index_manager = require('./index_manager');
 const {
+  touchIndexEntry,
+  incrementEditCount,
+} = require('../tools/context_priority');
+const {
   ensure_dir,
   normalize_memory_path,
 } = require('../tools/file_utils');
@@ -80,6 +84,8 @@ async function save_memory(user_id, repo, token, filename, content) {
       console.error(`[storage.saveMemory] GitHub write failed for ${normalized}`, e.message);
     }
   }
+  touchIndexEntry(normalized);
+  incrementEditCount(normalized);
   return normalized;
 }
 

--- a/memory.js
+++ b/memory.js
@@ -1,7 +1,10 @@
 const { read_memory, save_memory, get_file } = require('./logic/storage');
 const { restore_context } = require('./context');
 const { getContextFiles } = require('./tools/index_manager');
-const { updateContextPriority, touchIndexEntry } = require('./tools/context_priority');
+const {
+  updateContextPriority,
+  touchIndexEntry,
+} = require('./tools/context_priority');
 const memory_config = require('./tools/memory_config');
 const token_store = require('./tools/token_store');
 const { normalize_memory_path } = require('./tools/file_utils');
@@ -93,7 +96,6 @@ async function saveMemory(repo, token, filename, content) {
   try {
     const result = await save_memory(null, repo, token, filename, content);
     logger.info('[saveMemory] success');
-    touchIndexEntry(normalized_file);
     return result;
   } catch (e) {
     logger.error('[saveMemory] error', e.message);

--- a/memory/index.json
+++ b/memory/index.json
@@ -5,7 +5,10 @@
     "title": "Profile",
     "lastModified": "2025-06-21T17:07:52.802Z",
     "context_priority": "high",
-    "last_accessed": "2025-06-24T21:14:16.803Z"
+    "last_accessed": "2025-06-24T21:24:48.702Z",
+    "access_count": 1,
+    "edit_count": 0,
+    "pinned": false
   },
   {
     "path": "memory/lessons/04_example.md",
@@ -13,7 +16,10 @@
     "title": "Example Lesson",
     "lastModified": "2025-06-21T17:07:52.802Z",
     "context_priority": "high",
-    "last_accessed": "2025-06-24T21:14:16.807Z"
+    "last_accessed": "2025-06-24T21:24:48.707Z",
+    "access_count": 5,
+    "edit_count": 3,
+    "pinned": false
   },
   {
     "path": "memory/plan_checklist.md",
@@ -22,6 +28,9 @@
     "description": "- [ ] Example task - [x] Не затирать index.json при обновлении",
     "lastModified": "2025-06-21T17:07:52.802Z",
     "context_priority": "high",
-    "last_accessed": "2025-06-24T21:14:16.808Z"
+    "last_accessed": "2025-06-24T21:24:48.707Z",
+    "access_count": 4,
+    "edit_count": 2,
+    "pinned": false
   }
 ]


### PR DESCRIPTION
## Summary
- track access/edit statistics for memory files
- adjust context priority based on usage
- update index entries with default statistics
- record file edits when saving

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b16c137d0832392787a446bf5a907