### PR TITLE
Fix path encoding for GitHub client

### DIFF
--- a/memory.js
+++ b/memory.js
@@ -9,6 +9,7 @@ const memory_config = require('./tools/memory_config');
 const token_store = require('./tools/token_store');
 const { normalize_memory_path } = require('./tools/file_utils');
 const logger = require('./utils/logger');
+const { encodePath } = require('./tools/github_client');
 
 function normalize_repo(repo) {
   if (!repo) return repo;
@@ -59,7 +60,7 @@ async function readMemory(repo, token, filename) {
   const normalized_file = normalize_memory_path(target);
 
   if (final_repo && final_token) {
-    const url = `https://api.github.com/repos/${normalize_repo(final_repo)}/contents/${encodeURIComponent(normalized_file)}`;
+    const url = `https://api.github.com/repos/${normalize_repo(final_repo)}/contents/${encodePath(normalized_file)}`;
     console.log('[readMemory] url', url);
   }
 
@@ -89,7 +90,7 @@ async function saveMemory(repo, token, filename, content) {
   });
 
   if (final_repo && final_token) {
-    const url = `https://api.github.com/repos/${normalize_repo(final_repo)}/contents/${encodeURIComponent(normalized_file)}`;
+    const url = `https://api.github.com/repos/${normalize_repo(final_repo)}/contents/${encodePath(normalized_file)}`;
     logger.debug('[saveMemory] request url', url);
   }
 

--- a/tests/github_client.test.js
+++ b/tests/github_client.test.js
@@ -1,0 +1,22 @@
+const assert = require('assert');
+const axios = require('axios');
+const github = require('../tools/github_client');
+
+(async function run(){
+  const origGet = axios.get;
+  const origPut = axios.put;
+  let capturedUrl = null;
+  axios.get = async () => { const err = new Error('nf'); err.response = { status: 404 }; throw err; };
+  axios.put = async (url) => { capturedUrl = url; return { status: 201 }; };
+
+  await github.writeFile('tok','user/repo','subdir/test.md','Hi','msg');
+  assert.strictEqual(
+    capturedUrl,
+    'https://api.github.com/repos/user/repo/contents/subdir/test.md'
+  );
+
+  axios.get = origGet;
+  axios.put = origPut;
+  console.log('github_client path test passed');
+})();
+

--- a/tools/github_client.js
+++ b/tools/github_client.js
@@ -4,6 +4,10 @@ const { Octokit } = require('@octokit/rest');
 const axios = require('axios');
 const { logError } = require('./error_handler');
 
+function encodePath(p) {
+  return p.split('/').map(encodeURIComponent).join('/');
+}
+
 function normalizeRepo(repo) {
   if (!repo) return repo;
   const match = repo.match(/github\.com[:\/](.+?)(?:\.git)?$/);
@@ -37,7 +41,7 @@ exports.repoExists = async function (token, repo) {
 
 exports.readFile = async function (token, repo, filePath) {
   const normalized = normalizeRepo(repo);
-  const url = `https://api.github.com/repos/${normalized}/contents/${encodeURIComponent(filePath)}`;
+  const url = `https://api.github.com/repos/${normalized}/contents/${encodePath(filePath)}`;
   const masked = token ? `${token.slice(0, 4)}...` : 'null';
   console.log('[readFile] Repo:', normalized);
   console.log('[readFile] Token:', masked);
@@ -57,7 +61,7 @@ exports.readFile = async function (token, repo, filePath) {
 
 exports.writeFile = async function(token, repo, filePath, content, message) {
   const normalized = normalizeRepo(repo);
-  const url = `https://api.github.com/repos/${normalized}/contents/${encodeURIComponent(filePath)}`;
+  const url = `https://api.github.com/repos/${normalized}/contents/${encodePath(filePath)}`;
   const masked = token ? `${token.slice(0, 4)}...` : 'null';
   console.log('[writeFile] Repo:', normalized);
   console.log('[writeFile] Token:', masked);
@@ -101,4 +105,6 @@ exports.writeFileSafe = async function(
     }
   }
 };
+
+exports.encodePath = encodePath;
 


### PR DESCRIPTION
## Summary
- ensure GitHub paths are encoded per segment
- adjust logging to use encodePath
- test URL handling in github_client.writeFile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b1d3e03fc83239245bf96fc1750e0