### PR TITLE
Automatic context refresh support

### DIFF
--- a/Instruction.md
+++ b/Instruction.md
@@ -1,1 +1,3 @@
 11. GPT must call `restoreContext()` when context is lost. If `TEST_MODE` is enabled, confirm with the user before restoring.
+12. The plugin tracks a `needs_context_refresh` flag. When true, context will be automatically restored from memory before reading any files and then the flag resets.
+13. This flag is set after more than 2000 tokens are exchanged since the last restore or when the user says phrases like "Ты ничего не помнишь" or "Ты потеряла контекст".

--- a/memory/instructions/base.md
+++ b/memory/instructions/base.md
@@ -1,2 +1,3 @@
 # Base Instructions
 Default instructions for Sofia.
+The system uses a `needs_context_refresh` flag to automatically reload the chat context from memory when it becomes true. The flag is raised after about 2000 tokens or if the user explicitly notes memory loss, and it resets after the refresh completes.

--- a/tools/context_state.js
+++ b/tools/context_state.js
@@ -1,0 +1,77 @@
+const fs = require('fs');
+const path = require('path');
+
+const cache_dir = path.join(__dirname, '.cache');
+const state_file = path.join(cache_dir, 'context_state.json');
+
+let state = { needs_refresh: false, tokens: 0, _loaded: false };
+
+function load() {
+  if (state._loaded) return;
+  try {
+    if (fs.existsSync(state_file)) {
+      const raw = fs.readFileSync(state_file, 'utf-8');
+      const data = JSON.parse(raw);
+      state.needs_refresh = !!data.needs_refresh;
+      state.tokens = data.tokens || 0;
+    }
+  } catch {}
+  state._loaded = true;
+}
+
+function save() {
+  if (!fs.existsSync(cache_dir)) fs.mkdirSync(cache_dir, { recursive: true });
+  const data = { needs_refresh: state.needs_refresh, tokens: state.tokens };
+  fs.writeFileSync(state_file, JSON.stringify(data, null, 2), 'utf-8');
+}
+
+function get_needs_refresh() {
+  load();
+  return !!state.needs_refresh;
+}
+
+function set_needs_refresh(val) {
+  load();
+  state.needs_refresh = !!val;
+  save();
+}
+
+function get_tokens() {
+  load();
+  return state.tokens || 0;
+}
+
+function increment_tokens(n = 0) {
+  load();
+  state.tokens += n;
+  if (state.tokens > 2000) state.needs_refresh = true;
+  save();
+}
+
+function reset_tokens() {
+  load();
+  state.tokens = 0;
+  save();
+}
+
+function register_user_prompt(prompt = '') {
+  const len = typeof prompt === 'string' ? prompt.length : 0;
+  increment_tokens(len);
+  const triggers = [
+    /ты ничего не помнишь/i,
+    /ты потеряла контекст/i,
+    /вспомни урок/i,
+  ];
+  if (triggers.some(r => r.test(prompt))) {
+    set_needs_refresh(true);
+  }
+}
+
+module.exports = {
+  get_needs_refresh,
+  set_needs_refresh,
+  get_tokens,
+  increment_tokens,
+  reset_tokens,
+  register_user_prompt,
+};


### PR DESCRIPTION
## Summary
- add new `context_state` module to persist refresh flag and token counter
- auto refresh context before memory reads when `needs_context_refresh` is true
- track token usage and triggers in `context.js`
- expose helper `register_user_prompt`
- document flag logic in instructions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b291837348323afe886ca12b00c6f