### PR TITLE
Implement reference answer saving and utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ npm test
 - `POST /read` \u2014 прочитать содержимое файла;
 - `POST /saveMemory` и `POST /readMemory` \u2014 работа с основной памятью;
 - `POST /saveMemoryWithIndex` \u2014 сохранить файл и обновить `index.json`;
+- `POST /saveAnswer` \u2014 сохранить эталонный ответ;
 - `POST /saveLessonPlan` \u2014 обновить план обучения;
 - `POST /setMemoryRepo` \u2014 задать репозиторий пользователя;
 - `POST /version/commit` и `POST /version/rollback` \u2014 управление версиями инструкций;

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -138,6 +138,19 @@ paths:
       responses:
         '200':
           description: Saved
+  /saveAnswer:
+    post:
+      summary: Save reference answer
+      operationId: saveAnswer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SaveAnswerRequest'
+      responses:
+        '200':
+          description: Saved
   /getToken:
     post:
       summary: Get stored GitHub token
@@ -210,3 +223,16 @@ components:
           type: array
           items:
             type: string
+    SaveAnswerRequest:
+      type: object
+      properties:
+        key:
+          type: string
+        content:
+          type: string
+        repo:
+          type: string
+        token:
+          type: string
+        userId:
+          type: string

--- a/tests/save_reference_answer.test.js
+++ b/tests/save_reference_answer.test.js
@@ -1,0 +1,21 @@
+process.env.NO_GIT = "true";
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const { saveReferenceAnswer } = require('../memory');
+const { parse_save_reference_answer } = require('../tools/utils');
+
+(async function run(){
+  const cmd = 'Сохрани это как эталонный ответ vector_basics';
+  const parsed = parse_save_reference_answer(cmd);
+  assert.strictEqual(parsed.key, 'vector_basics');
+
+  const rel = 'memory/answers/vector_basics.md';
+  await saveReferenceAnswer(null, null, 'vector_basics', 'Answer');
+  const abs = path.join(__dirname, '..', rel);
+  assert.ok(fs.existsSync(abs));
+  const data = fs.readFileSync(abs, 'utf-8');
+  assert.strictEqual(data, 'Answer');
+  fs.unlinkSync(abs);
+  console.log('save reference answer test passed');
+})();

--- a/tools/file_utils.js
+++ b/tools/file_utils.js
@@ -68,6 +68,7 @@ function inferTypeFromPath(p) {
   if (p.includes('plan')) return 'plan';
   if (p.includes('profile')) return 'profile';
   if (p.includes('lesson')) return 'lesson';
+  if (p.includes('answers') || p.includes('answer')) return 'answer';
   if (p.includes('note')) return 'note';
   return 'file';
 }

--- a/tools/memory_helpers.js
+++ b/tools/memory_helpers.js
@@ -56,6 +56,7 @@ function categorizeMemoryFile(name) {
   if (lower.includes('note')) return 'note';
   if (lower.includes('context')) return 'context';
   if (lower.includes('practice')) return 'practice';
+  if (lower.includes('answer')) return 'answer';
 
   if (['.txt', '.json'].includes(ext)) return 'lesson';
   if (

--- a/tools/utils.js
+++ b/tools/utils.js
@@ -46,7 +46,25 @@ function parse_user_memory_setup(message = '') {
   return { userId, repo, token };
 }
 
+// Parse command like "\u0421\u043e\u0445\u0440\u0430\u043d\u0438 \u044d\u0442\u043e \u043a\u0430\u043a \u044d\u0442\u0430\u043b\u043e\u043d\u043d\u044b\u0439 \u043e\u0442\u0432\u0435\u0442 key"
+function parse_save_reference_answer(message = '') {
+  if (typeof message !== 'string') return null;
+  const m = message.match(/сохрани это как эталонный ответ\s+(\S+)/i);
+  if (!m) return null;
+  return { key: m[1] };
+}
+
+// Parse command like "\u0417\u0430\u0433\u0440\u0443\u0437\u0438 answers/file.md \u0432 \u0442\u0435\u043a\u0443\u0449\u0438\u0439 \u0434\u0438\u0430\u043b\u043e\u0433"
+function parse_manual_load_command(message = '') {
+  if (typeof message !== 'string') return null;
+  const m = message.match(/загрузи\s+(\S+)\s+в\s+текущий\s+диалог/i);
+  if (!m) return null;
+  return { path: m[1] };
+}
+
 module.exports = {
-  parse_user_memory_setup
+  parse_user_memory_setup,
+  parse_save_reference_answer,
+  parse_manual_load_command
 };
 


### PR DESCRIPTION
## Summary
- support `/saveAnswer` endpoint
- expose helper commands to parse reference answer and load commands
- enforce token limits when saving memory
- allow saving reference answers via `saveReferenceAnswer`
- document new endpoint in README and openapi
- add tests for reference answer saving

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c31c6c58c8323a45656fe903cf9fc