### PR TITLE
Implement automatic memory file splitting

### DIFF
--- a/tests/memory_split.test.js
+++ b/tests/memory_split.test.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+process.env.NO_INDEX_UPDATE = 'true';
+const { split_memory_file } = require('../tools/memory_splitter');
+const { readMemory } = require('../memory');
+const index_manager = require('../logic/index_manager');
+
+const tmp_dir = path.join(__dirname, '..', 'memory', 'tmp_split');
+if (!fs.existsSync(tmp_dir)) fs.mkdirSync(tmp_dir, { recursive: true });
+
+async function run(){
+  const rel = 'memory/tmp_split/long.md';
+  const abs = path.join(__dirname, '..', rel);
+  const parts = [];
+  for(let i=0;i<30;i++) parts.push('word'.repeat(1));
+  const content = '# Long\n\n' + parts.map(w=>w+' '+w+' '+w).join('\n\n');
+  fs.writeFileSync(abs, content);
+
+  const result = await split_memory_file(rel, 10);
+  assert.ok(result.length > 1);
+  const index_path = path.join(__dirname, '..', 'memory', 'tmp_split', 'long', 'index.md');
+  assert.ok(fs.existsSync(index_path));
+
+  const read = await readMemory(null, null, rel);
+  assert.ok(read.includes('word word'));
+
+  fs.rmSync(path.join(__dirname, '..', 'memory', 'tmp_split'), { recursive: true, force: true });
+  await index_manager.removeEntry('memory/tmp_split/long/index.md');
+  await index_manager.saveIndex();
+  console.log('memory split tests passed');
+}
+
+run();

--- a/tools/memory_splitter.js
+++ b/tools/memory_splitter.js
@@ -1,0 +1,101 @@
+const fs = require('fs');
+const path = require('path');
+const index_manager = require('../logic/index_manager');
+const { ensure_dir, normalize_memory_path } = require('./file_utils');
+
+function count_tokens(text = '') {
+  return String(text).split(/\s+/).filter(Boolean).length;
+}
+
+function split_into_blocks(md) {
+  const lines = md.split(/\r?\n/);
+  const has_anchor = lines.some(l => /<!--\s*START:/i.test(l));
+  if (!has_anchor) {
+    return md
+      .split(/\n{2,}/)
+      .map(p => p.trim())
+      .filter(Boolean);
+  }
+  const blocks = [];
+  let current = [];
+  for (const line of lines) {
+    if (/<!--\s*START:/i.test(line) && current.length) {
+      blocks.push(current.join('\n'));
+      current = [];
+    }
+    current.push(line);
+    if (/<!--\s*END:/i.test(line)) {
+      blocks.push(current.join('\n'));
+      current = [];
+    }
+  }
+  if (current.length) blocks.push(current.join('\n'));
+  return blocks;
+}
+
+async function split_memory_file(filename, max_tokens) {
+  const normalized = normalize_memory_path(filename);
+  const abs = path.join(__dirname, '..', normalized);
+  if (!fs.existsSync(abs)) throw new Error('File not found');
+  const original = fs.readFileSync(abs, 'utf-8');
+  const total_tokens = count_tokens(original);
+  if (total_tokens <= max_tokens) return [normalized];
+
+  const dir = abs.replace(/\.md$/i, '');
+  ensure_dir(dir);
+  const rel_dir = normalized.replace(/\.md$/i, '');
+
+  const blocks = split_into_blocks(original);
+  const parts = [];
+  let buf = [];
+  let tok = 0;
+  const flush = () => {
+    if (!buf.length) return;
+    parts.push(buf.join('\n\n').trim());
+    buf = [];
+    tok = 0;
+  };
+  blocks.forEach(b => {
+    const t = count_tokens(b);
+    if (buf.length && tok + t > max_tokens) flush();
+    buf.push(b);
+    tok += t;
+  });
+  flush();
+
+  parts.forEach((p, idx) => {
+    const part_path = path.join(dir, `part${idx + 1}.md`);
+    fs.writeFileSync(part_path, p + '\n', 'utf-8');
+  });
+
+  const title_match = original.match(/^#\s*(.+)/);
+  const title = title_match ? title_match[1].trim() : path.basename(filename, '.md');
+  const meta_lines = [
+    '---',
+    `title: ${title}`,
+    `parts: [${parts.map((_, i) => `part${i + 1}.md`).join(', ')}]`,
+    `tokens_total: ${total_tokens}`,
+    'split: auto',
+    `updated: ${new Date().toISOString().slice(0, 10)}`,
+    '---',
+    ''
+  ];
+  fs.writeFileSync(path.join(dir, 'index.md'), meta_lines.join('\n'), 'utf-8');
+
+  fs.unlinkSync(abs);
+
+  const new_rel = path.posix.join(rel_dir, 'index.md');
+  if (!process.env.NO_INDEX_UPDATE) {
+    await index_manager.removeEntry(normalized);
+    await index_manager.addOrUpdateEntry({
+      path: new_rel,
+      title: index_manager.generateTitleFromPath(new_rel),
+      type: index_manager.inferTypeFromPath(new_rel),
+      lastModified: new Date().toISOString(),
+    });
+    await index_manager.saveIndex();
+  }
+  return parts.map((_, i) => path.posix.join(rel_dir, `part${i + 1}.md`));
+}
+
+module.exports = { split_memory_file };


### PR DESCRIPTION
## Summary
- add `split_memory_file` utility for automatic splitting of large markdown files
- integrate splitting logic into `saveMemory` and storage's `save_memory_with_index`
- read from generated index files when loading memory content
- include new tests for splitting behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c5002b7a483239d8890619dee5fea