### PR TITLE
Implement soft token guard with auto-split

### DIFF
--- a/logic/markdown_editor.js
+++ b/logic/markdown_editor.js
@@ -1,6 +1,11 @@
 const fs = require('fs');
 const path = require('path');
 const validator = require('./markdown_validator');
+const memory_settings = require('../tools/memory_settings');
+
+function count_tokens(text = '') {
+  return String(text).split(/\s+/).filter(Boolean).length;
+}
 
 function createBackup(filePath) {
   if (!fs.existsSync(filePath)) return null;
@@ -59,6 +64,11 @@ function writeLines(filePath, lines, force = false) {
   }
   createBackup(filePath);
   const data = Array.isArray(lines) ? lines.join('\n') : lines;
+  const tokens = count_tokens(data);
+  if (tokens > memory_settings.token_soft_limit && memory_settings.enforce_soft_limit) {
+    console.warn('[writeLines] token limit reached', tokens);
+    return false;
+  }
   fs.writeFileSync(filePath, data, 'utf-8');
   return true;
 }

--- a/logic/memory_operations.js
+++ b/logic/memory_operations.js
@@ -16,6 +16,7 @@ const {
   categorizeMemoryFile,
   logDebug,
 } = require('../tools/memory_helpers');
+const memory_settings = require('../tools/memory_settings');
 
 const contextFilename = path.join(__dirname, '..', 'memory', 'context.md');
 const planFilename = path.join(__dirname, '..', 'memory', 'plan.md');
@@ -251,6 +252,11 @@ function writeFileSafe(filePath, data, force = false) {
         if (!force) return;
       }
       mdEditor.createBackup(filePath);
+    }
+    const tokens = String(data).split(/\s+/).filter(Boolean).length;
+    if (tokens > memory_settings.token_soft_limit && memory_settings.enforce_soft_limit) {
+      console.warn('[writeFileSafe] token limit reached', tokens);
+      return;
     }
     fs.writeFileSync(filePath, data, 'utf-8');
     logDebug('[writeFileSafe] wrote', filePath);

--- a/logic/storage.js
+++ b/logic/storage.js
@@ -72,11 +72,13 @@ async function save_memory(user_id, repo, token, filename, content) {
   const tokens = count_tokens(content);
   if (tokens > memory_settings.token_soft_limit) {
     console.warn('[save_memory] token limit reached', tokens);
-    if (memory_settings.strict_guard) {
+    if (memory_settings.enforce_soft_limit) {
       return {
-        warning:
-          'This file has reached the safe size limit. Please restructure into subfiles before continuing.',
+        warning: 'This file is too large for safe future use.',
       };
+    } else {
+      const parts = await split_memory_file(normalized, memory_settings.max_tokens_per_file);
+      return { split: true, parts };
     }
   }
   const localPath = path.join(__dirname, '..', normalized);
@@ -112,11 +114,13 @@ async function save_memory_with_index(user_id, repo, token, filename, content) {
   const tokens = count_tokens(content);
   if (tokens > memory_settings.token_soft_limit) {
     console.warn('[save_memory_with_index] token limit reached', tokens);
-    if (memory_settings.strict_guard) {
+    if (memory_settings.enforce_soft_limit) {
       return {
-        warning:
-          'This file has reached the safe size limit. Please restructure into subfiles before continuing.',
+        warning: 'This file is too large for safe future use.',
       };
+    } else {
+      const parts = await split_memory_file(finalPath, memory_settings.max_tokens_per_file);
+      return { split: true, parts };
     }
   }
   if (tokens > memory_settings.max_tokens_per_file) {

--- a/memory.js
+++ b/memory.js
@@ -134,11 +134,14 @@ async function saveMemory(repo, token, filename, content) {
   const tokens = count_tokens(content);
   if (tokens > memory_settings.token_soft_limit) {
     console.warn('[saveMemory] token limit reached', tokens);
-    if (memory_settings.strict_guard) {
+    if (memory_settings.enforce_soft_limit) {
       return {
-        warning:
-          'This file has reached the safe size limit. Please restructure into subfiles before continuing.',
+        warning: 'This file is too large for safe future use.',
       };
+    } else {
+      const parts = await split_memory_file(filename, memory_settings.max_tokens_per_file);
+      logger.info('[saveMemory] auto split due to soft limit', { parts });
+      return { split: true, parts };
     }
   }
 

--- a/tools/memory_settings.js
+++ b/tools/memory_settings.js
@@ -1,5 +1,5 @@
 module.exports = {
   max_tokens_per_file: 4096,
   token_soft_limit: 2048,
-  strict_guard: true,
+  enforce_soft_limit: true,
 };


### PR DESCRIPTION
## Summary
- rename memory token guard setting to `enforce_soft_limit`
- block oversized saves in `memory.js` and `logic/storage.js`
- apply token checks to markdown editors and file utilities
- support token guard in helper write functions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c57087ec08323932bcb226db9af85