### PR TITLE
Enable automatic and manual context recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ npm test
 - `POST /saveMemoryWithIndex` \u2014 сохранить файл и обновить `index.json`;
 - `POST /saveAnswer` \u2014 сохранить эталонный ответ;
 - `POST /saveLessonPlan` \u2014 обновить план обучения;
+- `POST /loadMemoryToContext` \u2014 загрузить указанный файл в текущий контекст;
 - `POST /setMemoryRepo` \u2014 задать репозиторий пользователя;
 - `POST /version/commit` и `POST /version/rollback` \u2014 управление версиями инструкций;
 - `GET /profile` \u2014 получить сохраненный профиль;
@@ -76,4 +77,5 @@ npm test
 - Для поиска по ключевым словам используйте `searchByKeyword`.
 - `getContextFilesForKeywords` помогает подобрать файлы для восстановления контекста на основе темы диалога.
 - Вызов `sortIndexByPriority()` принудительно перестраивает порядок записей в `index.json`.
+- При старте сервера автоматически считываются файлы с `context_priority: high` и формируется базовый контекст. Команда `Восстанови контекст из <file>` загружает указанный файл вручную.
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const path = require('path');
 const fs = require('fs');
 const bodyParser = require('body-parser');
 const config = require('./config');
-const { setMemoryRepo } = require('./memory');
+const { setMemoryRepo, auto_recover_context } = require('./memory');
 
 // Мидлвар для разрешения CORS без внешних зависимостей
 function allow_cors(req, res, next) {
@@ -29,6 +29,9 @@ try {
 } catch (e) {
   console.error('[INIT] failed to set memory repo', e.message);
 }
+auto_recover_context().catch(e =>
+  console.error('[INIT] auto recover failed', e.message)
+);
 app.use(allow_cors);
 app.use(express.static(path.join(__dirname, 'assets')));
 app.use(bodyParser.json());

--- a/tests/context_recovery.test.js
+++ b/tests/context_recovery.test.js
@@ -1,0 +1,28 @@
+process.env.NO_GIT = "true";
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const { auto_recover_context, load_memory_to_context, setMemoryRepo } = require('../memory');
+const { contextFilename } = require('../logic/memory_operations');
+
+async function run() {
+  setMemoryRepo(null, null);
+  const rel = 'memory/lessons/tmp_recover.md';
+  const abs = path.join(__dirname, '..', rel);
+  const data = ['---','context_priority: high','---','Temp'].join('\n');
+  fs.writeFileSync(abs, data);
+
+  const res = await auto_recover_context();
+  assert.ok(res && res.files.includes(rel));
+  assert.ok(fs.readFileSync(contextFilename, 'utf-8').includes('Temp'));
+
+  const manual = await load_memory_to_context(rel);
+  assert.ok(manual.tokens >= 1);
+
+  // cleanup
+  // note: file kept to avoid race with async index rebuild
+  fs.writeFileSync(contextFilename, '');
+  console.log('context recovery tests passed');
+}
+
+run();


### PR DESCRIPTION
## Summary
- implement `auto_recover_context` and `load_memory_to_context` helpers
- call automatic recovery during server startup
- expose new `/loadMemoryToContext` endpoint
- document usage and add regression tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c59494d0c832394c26dde9872f33a