### PR TITLE
Implement safe index update

### DIFF
--- a/logic/storage.js
+++ b/logic/storage.js
@@ -136,7 +136,11 @@ async function save_memory_with_index(user_id, repo, token, filename, content) {
     type: index_manager.inferTypeFromPath(savedPath),
     lastModified: new Date().toISOString(),
   });
-  await index_manager.saveIndex(token, repo, user_id);
+  const result = await index_manager.saveIndex(token, repo, user_id);
+  if (result && result.warning) {
+    console.warn(`[index] ${result.warning}`);
+  }
+  
   return savedPath;
 }
 


### PR DESCRIPTION
## Summary
- enhance `saveIndex` with diff-based safety checks and logging
- warn about aborted index update in `save_memory_with_index`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c771ccc1483238bb4518c0130eb10