### PR TITLE
Sanitize memory paths

### DIFF
--- a/tests/memory_path_normalization.test.js
+++ b/tests/memory_path_normalization.test.js
@@ -1,0 +1,12 @@
+const assert = require('assert');
+const { normalize_memory_path } = require('../tools/file_utils');
+
+(function run(){
+  assert.strictEqual(normalize_memory_path('../etc/passwd'), 'memory/etc/passwd');
+  assert.strictEqual(normalize_memory_path('memory/../etc/passwd'), 'memory/etc/passwd');
+  assert.strictEqual(normalize_memory_path('/../../secret'), 'memory/secret');
+  assert.strictEqual(normalize_memory_path('foo/../bar'), 'memory/bar');
+  assert.strictEqual(normalize_memory_path('memory/bar'), 'memory/bar');
+  assert.strictEqual(normalize_memory_path('..'), 'memory/');
+  console.log('memory path normalization tests passed');
+})();


### PR DESCRIPTION
## Summary
- ensure `normalize_memory_path` removes `..` segments
- keep normalized paths within the memory directory
- add unit test for path normalization

## Testing
- `node tests/memory_path_normalization.test.js`
- `node tests/runAll.js` *(fails: AssertionError in index_manager_validation.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_685ce705bbb88323a9120873d31301d3