### PR TITLE
Implement backup on memory split

### DIFF
--- a/tests/index_manager_validation.test.js
+++ b/tests/index_manager_validation.test.js
@@ -19,5 +19,6 @@ const index_manager = require('../logic/index_manager');
 
   // cleanup
   fs.writeFileSync(idxPath, original, 'utf-8');
+  await index_manager.loadIndex();
   console.log('index manager validation passed');
 })();

--- a/tests/memory_split.test.js
+++ b/tests/memory_split.test.js
@@ -19,6 +19,8 @@ async function run(){
 
   const result = await split_memory_file(rel, 10);
   assert.ok(result.length > 1);
+  const backup_path = abs + '.bak';
+  assert.ok(fs.existsSync(backup_path));
   const index_path = path.join(__dirname, '..', 'memory', 'tmp_split', 'long', 'index.md');
   assert.ok(fs.existsSync(index_path));
 
@@ -26,6 +28,7 @@ async function run(){
   assert.ok(read.includes('word word'));
 
   fs.rmSync(path.join(__dirname, '..', 'memory', 'tmp_split'), { recursive: true, force: true });
+  fs.rmSync(backup_path, { force: true });
   await index_manager.removeEntry('memory/tmp_split/long/index.md');
   await index_manager.saveIndex();
   console.log('memory split tests passed');

--- a/tools/memory_splitter.js
+++ b/tools/memory_splitter.js
@@ -38,6 +38,12 @@ async function split_memory_file(filename, max_tokens) {
   const abs = path.join(__dirname, '..', normalized);
   if (!fs.existsSync(abs)) throw new Error('File not found');
   const original = fs.readFileSync(abs, 'utf-8');
+  const backupPath = `${abs}.bak`;
+  try {
+    fs.copyFileSync(abs, backupPath);
+  } catch (_) {
+    // ignore backup errors
+  }
   const total_tokens = count_tokens(original);
   if (total_tokens <= max_tokens) return [normalized];
 


### PR DESCRIPTION
## Summary
- backup markdown files before splitting
- verify backups when splitting memory files
- keep index manager cache in sync during tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685cf27b8d8c8323a48c2b9c40a6a4e9