### PR TITLE
Use context_priority when sorting index

### DIFF
--- a/tests/index_priority_sort.test.js
+++ b/tests/index_priority_sort.test.js
@@ -1,0 +1,29 @@
+process.env.NO_GIT = "true";
+const assert = require('assert');
+const { sort_by_priority } = require('../tools/index_utils');
+const index_tree = require('../tools/index_tree');
+
+(async function run() {
+  // direct sort_by_priority with context_priority fallback
+  const sample = [
+    { title: 'low', context_priority: 'low' },
+    { title: 'medium', context_priority: 'medium' },
+    { title: 'high', context_priority: 'high' }
+  ];
+  const sorted = sort_by_priority(sample);
+  const order = sorted.map(e => e.title);
+  assert.deepStrictEqual(order, ['high', 'medium', 'low']);
+
+  // ensure files from index tree are sorted with context_priority
+  const loaded = sort_by_priority(index_tree.listAllEntries());
+  const highestIndexInLoaded = loaded.findIndex(
+    e => (e.context_priority || '').toLowerCase() !== 'high'
+  );
+  const firstNonHigh = highestIndexInLoaded >= 0 ? highestIndexInLoaded : loaded.length;
+  const highCount = loaded.filter(
+    e => (e.context_priority || '').toLowerCase() === 'high'
+  ).length;
+  assert.ok(firstNonHigh >= highCount, 'high priority entries should come first');
+
+  console.log('index priority sort test passed');
+})();

--- a/tools/index_utils.js
+++ b/tools/index_utils.js
@@ -69,8 +69,8 @@ function array_to_index(arr) {
 function sort_by_priority(arr) {
   const order = { high: 0, medium: 1, low: 2 };
   return arr.slice().sort((a, b) => {
-    const pa = order[a.priority] ?? 3;
-    const pb = order[b.priority] ?? 3;
+    const pa = order[a.priority || a.context_priority] ?? 3;
+    const pb = order[b.priority || b.context_priority] ?? 3;
     if (pa === pb) return 0;
     return pa - pb;
   });


### PR DESCRIPTION
## Summary
- ensure sort_by_priority falls back to `context_priority`
- add regression test for priority sorting

## Testing
- `node tests/index_priority_sort.test.js`
- `npm test` *(fails: AssertionError in index_manager_validation.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_685cf89f348883238222fc389803e20f