### PR TITLE
Add metadata retention to saveIndex

### DIFF
--- a/logic/index_manager.js
+++ b/logic/index_manager.js
@@ -232,11 +232,13 @@ async function saveIndex(token, repo, userId) {
     const branchEntries = indexData.filter(e =>
       e.path.replace(/^memory\//, '').startsWith(dir)
     );
-    const files = branchEntries.map(e => ({
-      title: e.title,
-      file: e.path.replace(/^memory\//, ''),
-      tags: e.tags || [],
-    }));
+    const files = branchEntries.map(e => {
+      const { path: filePath, ...meta } = e;
+      return {
+        ...meta,
+        file: filePath.replace(/^memory\//, ''),
+      };
+    });
     const abs = path.join(__dirname, '..', 'memory', b.path);
     ensure_dir(abs);
     fs.writeFileSync(

--- a/tests/index_save_metadata.test.js
+++ b/tests/index_save_metadata.test.js
@@ -1,0 +1,29 @@
+process.env.NO_GIT = "true";
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const index_manager = require('../logic/index_manager');
+
+(async function run() {
+  const idxPath = path.join(__dirname, '..', 'memory', 'plans', 'features', 'index.json');
+  const original = fs.readFileSync(idxPath, 'utf-8');
+
+  await index_manager.loadIndex();
+  await index_manager.addOrUpdateEntry({
+    path: 'memory/plans/features/limit_guard.md',
+    priority: 'high',
+    version: '1.2.3'
+  });
+
+  const data = JSON.parse(fs.readFileSync(idxPath, 'utf-8'));
+  const entry = data.files.find(f => f.file === 'plans/features/limit_guard.md');
+  assert.ok(entry, 'entry exists');
+  assert.strictEqual(entry.priority, 'high');
+  assert.strictEqual(entry.version, '1.2.3');
+  assert.ok(entry.lastModified);
+  assert.ok(entry.context_priority);
+
+  fs.writeFileSync(idxPath, original, 'utf-8');
+  await index_manager.loadIndex();
+  console.log('index save metadata test passed');
+})();


### PR DESCRIPTION
## Summary
- include metadata when generating branch entries in `saveIndex`
- add regression test for metadata persistence

## Testing
- `for f in tests/*.test.js; do node "$f" || { echo "Failed $f"; exit 1; }; done`

------
https://chatgpt.com/codex/tasks/task_e_685cfa5b602c83238d0add651c542acb