### PR TITLE
Implement index size limit and splitter

### DIFF
--- a/logic/index_manager.js
+++ b/logic/index_manager.js
@@ -14,6 +14,7 @@ const { logError } = require('../tools/error_handler');
 const { sort_by_priority } = require('../tools/index_utils');
 const index_tree = require('../tools/index_tree');
 const { indexSettings, validateIndex } = require('./index_validator');
+const { checkAndSplitIndex } = require('../tools/index_splitter');
 
 const indexPath = path.join(__dirname, '..', 'memory', 'index.json');
 let indexData = null;
@@ -245,6 +246,10 @@ async function saveIndex(token, repo, userId) {
       abs,
       JSON.stringify({ type: 'index-branch', category: b.category, files }, null, 2),
       'utf-8'
+    );
+    checkAndSplitIndex(
+      abs,
+      indexSettings.max_index_size || 100 * 1024
     );
   });
   return { saved: true };

--- a/logic/index_validator.js
+++ b/logic/index_validator.js
@@ -7,6 +7,7 @@ const indexSettings = {
   auto_clean_missing: false,
   require_manual_meta: true,
   block_plugin_paths: true,
+  max_index_size: 100 * 1024,
 };
 
 function normalize(p) {

--- a/tests/index_splitter.test.js
+++ b/tests/index_splitter.test.js
@@ -1,0 +1,26 @@
+process.env.NO_GIT = "true";
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const { checkAndSplitIndex } = require('../tools/index_splitter');
+const index_tree = require('../tools/index_tree');
+
+(function run(){
+  const idxPath = path.join(__dirname, '..', 'memory', 'drafts', 'index.json');
+  const original = fs.readFileSync(idxPath, 'utf-8');
+  const data = JSON.parse(original);
+  for(let i=0;i<50;i++){
+    data.files.push({title:`T${i}`, file:`drafts/t${i}.md`, tags:['t'], priority:'low', updated:'2024-01-01'});
+  }
+  fs.writeFileSync(idxPath, JSON.stringify(data, null, 2), 'utf-8');
+
+  checkAndSplitIndex(idxPath, 1000);
+  const part = path.join(__dirname, '..', 'memory', 'drafts', 'index.part2.json');
+  assert.ok(fs.existsSync(part), 'part index created');
+  const entries = index_tree.loadBranch('drafts');
+  assert.ok(entries.length >= data.files.length, 'entries loaded from parts');
+
+  fs.writeFileSync(idxPath, original, 'utf-8');
+  if(fs.existsSync(part)) fs.unlinkSync(part);
+  console.log('index splitter test passed');
+})();

--- a/tools/index_splitter.js
+++ b/tools/index_splitter.js
@@ -1,0 +1,68 @@
+const fs = require('fs');
+const path = require('path');
+
+function checkAndSplitIndex(indexPath, maxSize = 100 * 1024) {
+  if (!fs.existsSync(indexPath)) return;
+  const stats = fs.statSync(indexPath);
+  if (stats.size <= maxSize) return;
+  splitIndexFile(indexPath, maxSize);
+}
+
+function splitIndexFile(indexPath, maxSize = 100 * 1024) {
+  if (!fs.existsSync(indexPath)) return;
+  const raw = fs.readFileSync(indexPath, 'utf-8');
+  let data;
+  try {
+    data = JSON.parse(raw);
+  } catch (e) {
+    console.error('[index_splitter] invalid JSON', e.message);
+    return;
+  }
+  if (!Array.isArray(data.files)) return;
+
+  const dir = path.dirname(indexPath);
+  const base = path.basename(indexPath, '.json');
+
+  const parts = [];
+  let current = [];
+
+  const flush = () => {
+    if (!current.length) return;
+    parts.push(current);
+    current = [];
+  };
+
+  for (const entry of data.files) {
+    current.push(entry);
+    const temp = JSON.stringify({ ...data, files: current });
+    if (Buffer.byteLength(temp, 'utf-8') > maxSize && current.length > 1) {
+      current.pop();
+      flush();
+      current.push(entry);
+    }
+  }
+  flush();
+
+  parts.forEach((files, idx) => {
+    const outPath = idx === 0 ? indexPath : path.join(dir, `${base}.part${idx + 1}.json`);
+    fs.writeFileSync(outPath, JSON.stringify({ ...data, files }, null, 2), 'utf-8');
+  });
+
+  // remove old extra parts
+  let n = parts.length + 1;
+  while (true) {
+    const extra = path.join(dir, `${base}.part${n}.json`);
+    if (fs.existsSync(extra)) {
+      fs.unlinkSync(extra);
+      n++;
+    } else {
+      break;
+    }
+  }
+
+  if (parts.length > 1) {
+    console.log(`[index_splitter] split ${indexPath} into ${parts.length} parts`);
+  }
+}
+
+module.exports = { checkAndSplitIndex, splitIndexFile };


### PR DESCRIPTION
## Summary
- add index_splitter utility to segment large index files
- load branch indices from multiple parts
- check branch index sizes when saving
- expose max_index_size setting
- test splitting behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d030da7e883239d0052b54efa6f3c