### PR TITLE
Implement file move with index update

### DIFF
--- a/logic/index_manager.js
+++ b/logic/index_manager.js
@@ -186,6 +186,22 @@ async function removeEntry(p) {
   indexData = sort_by_priority(indexData.filter(e => e.path !== p));
 }
 
+async function moveFileAndUpdateIndex(oldPath, newPath) {
+  const src = path.join(__dirname, '..', normalize_memory_path(oldPath));
+  const dstRel = normalize_memory_path(newPath);
+  const dst = path.join(__dirname, '..', dstRel);
+  ensure_dir(dst);
+  fs.renameSync(src, dst);
+
+  if (!indexData) await loadIndex();
+  indexData = indexData.filter(e => e.path !== normalize_memory_path(oldPath));
+  await addOrUpdateEntry({
+    path: dstRel,
+    title: generateTitleFromPath(dstRel),
+    type: inferTypeFromPath(dstRel),
+  });
+}
+
 async function saveIndex(token, repo, userId) {
   if (!indexData) await loadIndex();
   const old_list = index_tree.listAllEntries();
@@ -296,5 +312,6 @@ module.exports = {
   getLessonPath,
   markDuplicateLessons,
   addToIndex,
+  moveFileAndUpdateIndex,
   getValidationReport,
 };

--- a/tests/move_file_update_index.test.js
+++ b/tests/move_file_update_index.test.js
@@ -1,0 +1,31 @@
+process.env.NO_GIT = "true";
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const index_manager = require('../logic/index_manager');
+const index_tree = require('../tools/index_tree');
+
+(async function run() {
+  const old_rel = 'memory/lessons/intro.md';
+  const new_rel = 'memory/lessons/tmp_move/intro.md';
+  const old_abs = path.join(__dirname, '..', old_rel);
+  const new_abs = path.join(__dirname, '..', new_rel);
+  const idx_path = path.join(__dirname, '..', 'memory', 'lessons', 'index.json');
+  const original_idx = fs.readFileSync(idx_path, 'utf-8');
+
+  await index_manager.moveFileAndUpdateIndex(old_rel, new_rel);
+  assert.ok(fs.existsSync(new_abs));
+  assert.ok(!fs.existsSync(old_abs));
+  const moved = index_tree.findEntryByPath(new_rel);
+  assert.ok(moved && moved.path === new_rel);
+
+  await index_manager.moveFileAndUpdateIndex(new_rel, old_rel);
+  assert.ok(fs.existsSync(old_abs));
+
+  fs.rmSync(path.dirname(new_abs), { recursive: true, force: true });
+  fs.writeFileSync(idx_path, original_idx, 'utf-8');
+  await index_manager.loadIndex();
+
+  console.log('move file update index tests passed');
+})();
+


### PR DESCRIPTION
## Summary
- add `moveFileAndUpdateIndex` helper to move files and update index references
- test moving memory files while keeping index.json consistent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d213f16ec8323bde9cac499717892