### PR TITLE
Improve GitHub error propagation

### DIFF
--- a/tools/github_client.js
+++ b/tools/github_client.js
@@ -60,6 +60,13 @@ exports.readFile = async function (token, repo, filePath) {
     console.log('[readFile] status:', res.status);
     return Buffer.from(res.data.content, 'base64').toString('utf-8');
   } catch (e) {
+    if (e.response) {
+      e.status = e.response.status;
+      if (e.response.data && e.response.data.message) {
+        e.githubMessage = e.response.data.message;
+        e.message = e.response.data.message;
+      }
+    }
     logError('readFile', e);
     throw e;
   }
@@ -92,6 +99,13 @@ exports.writeFile = async function(token, repo, filePath, content, message) {
       headers: { Authorization: `token ${token}`, ...DEFAULT_HEADERS }
     });
   } catch (e) {
+    if (e.response) {
+      e.status = e.response.status;
+      if (e.response.data && e.response.data.message) {
+        e.githubMessage = e.response.data.message;
+        e.message = e.response.data.message;
+      }
+    }
     logError('writeFile', e);
     throw e;
   }

--- a/ui/memory_routes.js
+++ b/ui/memory_routes.js
@@ -110,7 +110,10 @@ async function saveMemory(req, res) {
     try {
       writeFileSafe(filePath, finalContent);
     } catch (e) {
-      return res.status(500).json({ status: 'error', message: e.message });
+      const code = e.status || 500;
+      return res
+        .status(code)
+        .json({ status: 'error', message: e.message, code, detail: e.githubMessage });
     }
 
     if (effectiveRepo) {
@@ -127,7 +130,10 @@ async function saveMemory(req, res) {
         );
       } catch (e) {
         logError('GitHub write', e);
-        return res.status(500).json({ status: 'error', message: e.message });
+        const code = e.status || 500;
+        return res
+          .status(code)
+          .json({ status: 'error', message: e.message, code, detail: e.githubMessage });
       }
     }
   }
@@ -165,7 +171,8 @@ async function saveAnswer(req, res) {
     await saveReferenceAnswer(r, t, key, content);
     res.json({ status: 'success', path: `memory/answers/${key}.md` });
   } catch (e) {
-    res.status(500).json({ status: 'error', message: e.message });
+    const code = e.status || 500;
+    res.status(code).json({ status: 'error', message: e.message, code, detail: e.githubMessage });
   }
 }
 
@@ -197,7 +204,10 @@ async function readMemory(req, res) {
       return res.json({ status: 'success', content });
     } catch (e) {
       console.error('[read] error remote', e.message);
-      return res.status(500).json({ status: 'error', message: e.message });
+      const code = e.status || 500;
+      return res
+        .status(code)
+        .json({ status: 'error', message: e.message, code, detail: e.githubMessage });
     }
   }
 
@@ -227,8 +237,8 @@ async function readFileRoute(req, res) {
     const content = await readMarkdownFile(filename, { repo: effectiveRepo, token: effectiveToken });
     res.json({ status: 'success', content });
   } catch (e) {
-    const code = /not found/i.test(e.message) ? 404 : 500;
-    res.status(code).json({ status: 'error', message: e.message });
+    const code = e.status || (/not found/i.test(e.message) ? 404 : 500);
+    res.status(code).json({ status: 'error', message: e.message, code, detail: e.githubMessage });
   }
 }
 
@@ -381,7 +391,8 @@ async function save(req, res) {
     res.json({ status: 'ok' });
   } catch (e) {
     logError('save endpoint', e);
-    res.status(500).json({ status: 'error', message: e.message });
+    const code = e.status || 500;
+    res.status(code).json({ status: 'error', message: e.message, code, detail: e.githubMessage });
   }
 }
 
@@ -406,7 +417,8 @@ router.post('/saveMemoryWithIndex', async (req, res) => {
     );
     res.json({ status: 'success', path: pathSaved });
   } catch (e) {
-    res.status(500).json({ status: 'error', message: e.message });
+    const code = e.status || 500;
+    res.status(code).json({ status: 'error', message: e.message, code, detail: e.githubMessage });
   }
 });
 router.post('/saveAnswer', saveAnswer);
@@ -439,7 +451,8 @@ router.post('/loadMemoryToContext', async (req, res) => {
     );
     res.json({ status: 'success', loaded: result.file });
   } catch (e) {
-    res.status(500).json({ status: 'error', message: e.message });
+    const code = e.status || 500;
+    res.status(code).json({ status: 'error', message: e.message, code, detail: e.githubMessage });
   }
 });
 router.post('/loadContextFromIndex', async (req, res) => {
@@ -462,7 +475,8 @@ router.post('/loadContextFromIndex', async (req, res) => {
     );
     res.json({ status: 'success', loaded: result ? result.files : [] });
   } catch (e) {
-    res.status(500).json({ status: 'error', message: e.message });
+    const code = e.status || 500;
+    res.status(code).json({ status: 'error', message: e.message, code, detail: e.githubMessage });
   }
 });
 router.post('/chat/setup', (req, res) => {


### PR DESCRIPTION
## Summary
- capture GitHub API error details in `github_client`
- surface GitHub error status/messages from API routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d3e43001483239824afe6dac24d9d