### PR TITLE
Implement drafts index cleanup

### DIFF
--- a/tests/drafts_index_cleaner.test.js
+++ b/tests/drafts_index_cleaner.test.js
@@ -1,0 +1,38 @@
+process.env.NO_GIT = "true";
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const { cleanDraftsIndex } = require('../tools/drafts_index_cleaner');
+
+(function run(){
+  const idxPath = path.join(__dirname, '..', 'memory', 'drafts', 'index.json');
+  const draftsDir = path.join(__dirname, '..', 'memory', 'drafts');
+  const original = fs.readFileSync(idxPath, 'utf-8');
+
+  // prepare test files
+  fs.writeFileSync(path.join(draftsDir, 'a.md'), 'A');
+  fs.writeFileSync(path.join(draftsDir, 'b.md'), 'B');
+
+  const data = JSON.parse(original);
+  data.files.push({title:'A1', file:'drafts/a.md'});
+  data.files.push({title:'Duplicate', file:'drafts/a.md'});
+  data.files.push({title:'B', file:'drafts/b.md'});
+  data.files.push({title:'Missing', file:'drafts/missing.md'});
+  fs.writeFileSync(idxPath, JSON.stringify(data, null, 2), 'utf-8');
+
+  cleanDraftsIndex();
+
+  const cleaned = JSON.parse(fs.readFileSync(idxPath, 'utf-8'));
+  const files = cleaned.files.map(e => e.file);
+  assert.ok(files.includes('drafts/a.md'), 'a.md kept');
+  assert.ok(files.includes('drafts/b.md'), 'b.md kept');
+  assert.ok(!files.includes('drafts/missing.md'), 'missing removed');
+  assert.strictEqual(files.filter(f => f === 'drafts/a.md').length, 1, 'duplicates removed');
+
+  // cleanup
+  fs.writeFileSync(idxPath, original, 'utf-8');
+  fs.unlinkSync(path.join(draftsDir, 'a.md'));
+  fs.unlinkSync(path.join(draftsDir, 'b.md'));
+
+  console.log('drafts index cleaner test passed');
+})();

--- a/tools/drafts_index_cleaner.js
+++ b/tools/drafts_index_cleaner.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const path = require('path');
+
+function cleanDraftsIndex(indexPath = path.join(__dirname, '..', 'memory', 'drafts', 'index.json')) {
+  if (!fs.existsSync(indexPath)) return;
+  let raw;
+  try {
+    raw = fs.readFileSync(indexPath, 'utf-8');
+  } catch (e) {
+    console.error('[drafts_index_cleaner] cannot read index', e.message);
+    return;
+  }
+  let data;
+  try {
+    data = JSON.parse(raw);
+  } catch (e) {
+    console.error('[drafts_index_cleaner] invalid JSON', e.message);
+    return;
+  }
+  if (!Array.isArray(data.files)) return;
+
+  const seen = new Set();
+  const cleaned = [];
+  data.files.forEach(entry => {
+    if (!entry || !entry.file) return;
+    const abs = path.join(__dirname, '..', 'memory', entry.file);
+    if (!fs.existsSync(abs)) return; // skip missing files
+    if (seen.has(entry.file)) return; // skip duplicates
+    seen.add(entry.file);
+    cleaned.push(entry);
+  });
+
+  data.files = cleaned;
+  fs.writeFileSync(indexPath, JSON.stringify(data, null, 2), 'utf-8');
+}
+
+if (require.main === module) cleanDraftsIndex();
+
+module.exports = { cleanDraftsIndex };


### PR DESCRIPTION
## Summary
- add a tool to clean `memory/drafts/index.json`
- add tests for drafts index cleaner

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d57f50c488323848ecc86c3501db8