### PR TITLE
Add universal markdown editor

### DIFF
--- a/logic/universal_md_editor.js
+++ b/logic/universal_md_editor.js
@@ -1,0 +1,59 @@
+const fs = require('fs');
+const mdEditor = require('./markdown_editor');
+
+function addSection(filePath, heading, lines, opts = {}) {
+  return mdEditor.insertSection(filePath, heading, lines, opts.force);
+}
+
+function addLabel(filePath, label, opts = {}) {
+  const { heading = undefined, level = 1, force = false } = opts;
+  let text = label;
+  if (/^[-*]/.test(text.trim())) text = '\\' + text;
+  try {
+    return mdEditor.insertAtAnchor({
+      filePath,
+      content: text,
+      heading,
+      level,
+      occurrence: 1,
+      position: 'after',
+      skipIfExists: true,
+      force
+    });
+  } catch (_) {
+    if (!fs.existsSync(filePath)) throw _;
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    if (raw.includes(text)) return false;
+    const lines = raw.split(/\r?\n/);
+    lines.push('', text);
+    fs.writeFileSync(filePath, lines.join('\n'), 'utf-8');
+    return true;
+  }
+}
+
+function addFootnote(filePath, id, text, opts = {}) {
+  const note = `[^${id}]: ${text}`;
+  const r = mdEditor.insertSection(filePath, 'Footnotes', [note], opts.force);
+  mdEditor.deduplicateMarkdown({ filePath, heading: 'Footnotes', force: opts.force });
+  return r;
+}
+
+function addElement(filePath, type, options = {}) {
+  switch (type) {
+    case 'section':
+      return addSection(filePath, options.heading, options.contentLines || [], options);
+    case 'label':
+      return addLabel(filePath, options.label, options);
+    case 'footnote':
+      return addFootnote(filePath, options.id, options.text, options);
+    default:
+      throw new Error('Unsupported element type');
+  }
+}
+
+module.exports = {
+  addSection,
+  addLabel,
+  addFootnote,
+  addElement
+};

--- a/tests/universal_md_editor.test.js
+++ b/tests/universal_md_editor.test.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const ume = require('../logic/universal_md_editor');
+
+const tmpDir = path.join(__dirname, 'tmp_universal');
+if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir);
+
+(async function run(){
+  const file = path.join(tmpDir, 'sample.md');
+  fs.writeFileSync(file, '# Title\n');
+
+  // add label
+  ume.addLabel(file, '**Done**');
+  let content = fs.readFileSync(file, 'utf-8');
+  assert.ok(content.includes('**Done**'));
+
+  // add footnote
+  ume.addFootnote(file, 'a1', 'note text');
+  content = fs.readFileSync(file, 'utf-8');
+  assert.ok(content.includes('## Footnotes'));
+  assert.ok(content.includes('[^a1]: note text'));
+
+  // add section via addElement
+  ume.addElement(file, 'section', { heading: 'New Section', contentLines: ['- item'] });
+  content = fs.readFileSync(file, 'utf-8');
+  assert.ok(content.includes('## New Section'));
+  assert.ok(content.includes('- item'));
+
+  console.log('universal md editor tests passed');
+})();


### PR DESCRIPTION
## Summary
- implement `logic/universal_md_editor.js` to insert labels, sections and footnotes
- add unit tests for the new module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d5eedf63c8323a0b9e75340793815