### PR TITLE
Update OpenAPI spec with tokenStatus alias

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -253,6 +253,18 @@ paths:
       responses:
         '200':
           description: Status info
+  /tokenStatus:
+    get:
+      summary: Check if a token is stored (alias)
+      operationId: tokenStatusAlias
+      parameters:
+        - in: query
+          name: userId
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Status info
   /saveContext:
     post:
       summary: Save context content


### PR DESCRIPTION
## Summary
- document `/tokenStatus` alias in `openapi.yaml`

## Testing
- `openapi-spec-validator openapi.yaml`
- `npm test` *(fails: Cannot find module 'ajv')*

------
https://chatgpt.com/codex/tasks/task_e_685d605309f08323bccf19d784bdc77a