### PR TITLE
Update skipIfExists search and add tests

### DIFF
--- a/logic/markdown_editor.js
+++ b/logic/markdown_editor.js
@@ -150,7 +150,7 @@ function insertAtAnchor({
   skipIfExists = false,
   prepend = false,
   append = false,
-  checkDistance = 5,
+  checkDistance = Infinity,
   force = false
 }) {
   validator.checkFileExists(filePath);
@@ -195,9 +195,14 @@ function insertAtAnchor({
   }
 
   if (skipIfExists) {
-    const start = Math.max(0, anchorIdx - checkDistance);
-    const end = Math.min(lines.length, anchorIdx + checkDistance);
-    const area = lines.slice(start, end).join('\n');
+    let area;
+    if (Number.isFinite(checkDistance)) {
+      const start = Math.max(0, anchorIdx - checkDistance);
+      const end = Math.min(lines.length, anchorIdx + checkDistance);
+      area = lines.slice(start, end).join('\n');
+    } else {
+      area = lines.join('\n');
+    }
     if (area.includes(newLines.join('\n'))) {
       return false;
     }

--- a/tests/markdown_anchor_nodup.test.js
+++ b/tests/markdown_anchor_nodup.test.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const mdEditor = require('../logic/markdown_editor');
+
+const tmpDir = path.join(__dirname, 'tmp_anchor_nodup');
+if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir);
+
+function read(p) { return fs.readFileSync(p, 'utf-8'); }
+
+(async function run() {
+  const file = path.join(tmpDir, 'dup.md');
+  fs.writeFileSync(file, '# T\n\n## Tasks\n');
+
+  const opts = {
+    filePath: file,
+    heading: 'Tasks',
+    level: 2,
+    content: '- item',
+    skipIfExists: true
+  };
+
+  mdEditor.insertAtAnchor(opts);
+  mdEditor.insertAtAnchor(opts);
+  mdEditor.insertAtAnchor(opts);
+
+  const txt = read(file);
+  assert.strictEqual((txt.match(/- item/g) || []).length, 1);
+
+  console.log('markdown anchor nodup tests passed');
+})();


### PR DESCRIPTION
## Summary
- adjust `insertAtAnchor` to search the entire file when checking for existing content
- default `checkDistance` now covers the whole document
- add regression test ensuring multiple calls do not duplicate lines

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d7207023483238daabbf4b28c5e71