### PR TITLE
Refactor fs sync calls

### DIFF
--- a/memory.js
+++ b/memory.js
@@ -362,7 +362,7 @@ async function load_memory_to_context(filename, repo, token) {
     token,
     source: 'manual-load',
   });
-  ensureContext();
+  await ensureContext();
   fs.appendFileSync(contextFilename, `${content}\n`);
   return { file: normalized, tokens: count_tokens(content) };
 }
@@ -395,7 +395,7 @@ async function load_context_from_index(index_path, repo, token) {
     }
   }
   if (!loaded.length) return null;
-  ensureContext();
+  await ensureContext();
   fs.writeFileSync(contextFilename, full.trim() + '\n');
   return { files: loaded, content: full.trim() };
 }
@@ -460,7 +460,7 @@ async function auto_recover_context() {
     }
   }
   if (!loaded.length) return null;
-  ensureContext();
+  await ensureContext();
   fs.writeFileSync(contextFilename, full.trim() + '\n');
   console.log(`Context restored from: ${loaded.join(', ')}`);
   return { files: loaded, content: full.trim() };

--- a/tools/markdown_finder.js
+++ b/tools/markdown_finder.js
@@ -3,9 +3,9 @@ const path = require('path');
 const { sanitizeIndex, readIndexSafe, listMemoryFiles, fileExistsInRepo } = require('../logic/memory_operations');
 const { normalize_memory_path } = require('./file_utils');
 
-function loadIndex() {
+async function loadIndex() {
   try {
-    return sanitizeIndex(readIndexSafe());
+    return await sanitizeIndex(readIndexSafe());
   } catch {
     return [];
   }
@@ -20,8 +20,8 @@ function matchQuery(entry, query, regex) {
     p.startsWith(q) || p.endsWith(q) || t.startsWith(q) || t.endsWith(q);
 }
 
-function searchIndex(query) {
-  const idx = loadIndex();
+async function searchIndex(query) {
+  const idx = await loadIndex();
   const regex = query.startsWith('/') && query.endsWith('/') ? new RegExp(query.slice(1, -1), 'i') : null;
   const matches = idx.filter(e => matchQuery(e, query, regex));
   return matches.map(e => e.path);
@@ -47,7 +47,7 @@ async function resolveMarkdownPath(query, opts = {}) {
     if (fs.existsSync(abs)) return candidate;
   }
 
-  let matches = searchIndex(candidate);
+  let matches = await searchIndex(candidate);
   if (!matches.length) {
     matches = await searchFiles(candidate);
   }

--- a/ui/memory_routes.js
+++ b/ui/memory_routes.js
@@ -108,7 +108,7 @@ async function saveMemory(req, res) {
     }
   } else {
     try {
-      writeFileSafe(filePath, finalContent);
+      await writeFileSafe(filePath, finalContent);
     } catch (e) {
       const code = e.status || 500;
       return res
@@ -279,7 +279,7 @@ async function saveContext(req, res) {
   const { repo: effectiveRepo, token: effectiveToken } = getRepoInfo('memory/context.md', userId, repo, token);
 
   ensure_dir(contextFilename);
-  writeFileSafe(contextFilename, content || '');
+  await writeFileSafe(contextFilename, content || '');
 
   if (effectiveRepo && effectiveToken) {
     try {


### PR DESCRIPTION
## Summary
- switch memory operations to use `fs.promises`
- update plan loading and json helpers to async style
- adjust API routes and memory helpers to await async operations
- update markdown finder to handle async index access

## Testing
- `npm test` *(fails: Cannot find module 'ajv')*

------
https://chatgpt.com/codex/tasks/task_e_685d7a7063448323a4bbd007867b5728