### PR TITLE
Fix logging to use shared logger

### DIFF
--- a/memory.js
+++ b/memory.js
@@ -28,7 +28,7 @@ function count_tokens(text = '') {
 async function autoRefreshContext(repo, token) {
   if (context_state.get_needs_refresh()) {
     await refreshContextFromMemoryFiles(repo, token);
-    console.log('🔄 Context refreshed from memory repo');
+    logger.info('🔄 Context refreshed from memory repo');
     context_state.set_needs_refresh(false);
     context_state.reset_tokens();
   }
@@ -47,7 +47,7 @@ async function readMemory(repo, token, filename) {
 
   await autoRefreshContext(final_repo, final_token);
 
-  console.log('[readMemory] params', { repo: final_repo, token: masked_token, filename });
+  logger.info('[readMemory] params', { repo: final_repo, token: masked_token, filename });
 
   if (final_repo && !final_token) {
     throw new Error('API access is not possible due to missing token');
@@ -80,7 +80,7 @@ async function readMemory(repo, token, filename) {
 
   if (final_repo && final_token) {
     const url = `https://api.github.com/repos/${normalize_repo(final_repo)}/contents/${encodePath(normalized_file)}`;
-    console.log('[readMemory] url', url);
+    logger.debug('[readMemory] url', url);
   }
 
   try {
@@ -129,7 +129,7 @@ async function saveMemory(repo, token, filename, content) {
 
   const tokens = count_tokens(content);
   if (tokens > memory_settings.token_soft_limit) {
-    console.warn('[saveMemory] token limit reached', tokens);
+    logger.info('[saveMemory] token limit reached', tokens);
     if (memory_settings.enforce_soft_limit) {
       return {
         warning: 'This file is too large for safe future use.',
@@ -462,7 +462,7 @@ async function auto_recover_context() {
   if (!loaded.length) return null;
   await ensureContext();
   fs.writeFileSync(contextFilename, full.trim() + '\n');
-  console.log(`Context restored from: ${loaded.join(', ')}`);
+  logger.info(`Context restored from: ${loaded.join(', ')}`);
   return { files: loaded, content: full.trim() };
 }
 

--- a/ui/memory_routes.js
+++ b/ui/memory_routes.js
@@ -26,6 +26,7 @@ const { logError } = require('../tools/error_handler');
 const { readMarkdownFile } = require('../memory');
 const { saveReferenceAnswer } = require('../memory');
 const { load_memory_to_context, load_context_from_index } = require('../memory');
+const logger = require('../utils/logger');
 
 function setMemoryRepo(req, res) {
   const { repoUrl, userId } = req.body;
@@ -185,13 +186,13 @@ async function readMemory(req, res) {
   const filePath = path.join(__dirname, '..', normalizedFilename);
   const isJson = normalizedFilename.endsWith('.json');
 
-  console.log(`[read] repo=${effectiveRepo || 'local'} file=${normalizedFilename}`);
+  logger.info(`[read] repo=${effectiveRepo || 'local'} file=${normalizedFilename}`);
 
   if (effectiveRepo) {
     if (!effectiveToken) return res.status(401).json({ status: 'error', message: 'Missing GitHub token' });
     try {
       const content = await github.readFile(effectiveToken, effectiveRepo, normalizedFilename);
-      console.log(`[read] success remote ${normalizedFilename}`);
+      logger.info(`[read] success remote ${normalizedFilename}`);
       if (isJson) {
         try {
           const json = JSON.parse(content);
@@ -203,7 +204,7 @@ async function readMemory(req, res) {
       }
       return res.json({ status: 'success', content });
     } catch (e) {
-      console.error('[read] error remote', e.message);
+      logger.error('[read] error remote', e.message);
       const code = e.status || 500;
       return res
         .status(code)
@@ -212,11 +213,11 @@ async function readMemory(req, res) {
   }
 
   if (!fs.existsSync(filePath)) {
-    console.error('[read] file not found', filePath);
+    logger.error('[read] file not found', filePath);
     return res.status(404).json({ status: 'error', message: 'File not found.' });
   }
   const content = fs.readFileSync(filePath, 'utf-8');
-  console.log(`[read] success local ${normalizedFilename}`);
+  logger.info(`[read] success local ${normalizedFilename}`);
   if (isJson) {
     try {
       const json = JSON.parse(content);


### PR DESCRIPTION
## Summary
- replace direct console use in `memory.js`
- hook up logger in memory routes
- use proper log levels for memory API

## Testing
- `npm test` *(fails: Cannot read properties of undefined (reading 'forEach'))*

------
https://chatgpt.com/codex/tasks/task_e_685d88a5a0488323a4bfbc6c5572cb93