### PR TITLE
Add health and docs endpoints

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -399,6 +399,20 @@ paths:
       responses:
         '200':
           description: Pong
+  /health:
+    get:
+      summary: Render health check
+      operationId: health
+      responses:
+        '200':
+          description: OK
+  /docs:
+    get:
+      summary: List plugin endpoints
+      operationId: docs
+      responses:
+        '200':
+          description: Endpoint list
 components:
   schemas:
     SaveMemoryRequest:


### PR DESCRIPTION
## Summary
- document the new `/health` and `/docs` routes in `openapi.yaml`

## Testing
- `npm test` *(fails: index_consistency.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_685da62abe5c832396f94e44fb0dd3a0