### PR TITLE
Refactor markdown utilities

### DIFF
--- a/tools/memory_migrator.js
+++ b/tools/memory_migrator.js
@@ -2,23 +2,10 @@ const fs = require('fs');
 const path = require('path');
 const index_manager = require('../logic/index_manager');
 const { normalize_memory_path, generateTitleFromPath, inferTypeFromPath } = require('./file_utils');
+const { parseFrontMatter } = require('../utils/markdown_utils');
 
 const LATEST_VERSION = '1.2';
 
-function parse_front_matter(text = '') {
-  if (!text.startsWith('---')) return { meta: {}, body: text };
-  const end = text.indexOf('\n---', 3);
-  if (end < 0) return { meta: {}, body: text };
-  const header = text.slice(3, end).trim();
-  const body = text.slice(end + 4);
-  const meta = {};
-  header.split(/\r?\n/).forEach(line => {
-    const parts = line.split(':');
-    const key = parts.shift().trim();
-    meta[key] = parts.join(':').trim();
-  });
-  return { meta, body };
-}
 
 function build_front_matter(meta) {
   const lines = ['---'];
@@ -48,7 +35,7 @@ async function migrateMemoryFile(filename) {
   const abs = path.join(__dirname, '..', normalized);
   if (!fs.existsSync(abs)) throw new Error('File not found');
   const raw = fs.readFileSync(abs, 'utf-8');
-  const { meta, body } = parse_front_matter(raw);
+  const { meta, body } = parseFrontMatter(raw);
   const current_version = meta.version || null;
   if (current_version && parseFloat(current_version) >= parseFloat(LATEST_VERSION)) {
     return normalized;

--- a/utils/markdown_utils.js
+++ b/utils/markdown_utils.js
@@ -1,0 +1,47 @@
+function parseFrontMatter(text = '') {
+  if (!text.startsWith('---')) return { meta: {}, body: text };
+  const end = text.indexOf('\n---', 3);
+  if (end < 0) return { meta: {}, body: text };
+  const header = text.slice(3, end).trim();
+  const body = text.slice(end + 4);
+  const meta = {};
+  header.split(/\r?\n/).forEach(line => {
+    const parts = line.split(':');
+    const key = parts.shift().trim();
+    if (key) meta[key] = parts.join(':').trim();
+  });
+  return { meta, body };
+}
+
+function parseAutoIndex(text = '') {
+  const { meta } = parseFrontMatter(text);
+  if (!meta.files) {
+    const lines = text.split(/\r?\n/);
+    const idx = lines.findIndex(l => /^files:\s*/i.test(l.trim()));
+    if (idx >= 0) {
+      const arr = [];
+      for (let i = idx + 1; i < lines.length; i++) {
+        const ln = lines[i];
+        if (/^\s*-\s+/.test(ln)) {
+          arr.push(ln.replace(/^\s*-\s+/, '').trim());
+        } else if (/^[\w_-]+:\s*/.test(ln.trim())) {
+          break;
+        }
+      }
+      if (arr.length) meta.files = arr;
+    }
+  } else if (typeof meta.files === 'string') {
+    meta.files = meta.files
+      .replace(/^\[/, '')
+      .replace(/\]$/, '')
+      .split(/,|\r?\n/)
+      .map(t => t.replace(/^\s*-\s*/, '').trim())
+      .filter(Boolean);
+  }
+  return meta;
+}
+
+module.exports = {
+  parseFrontMatter,
+  parseAutoIndex,
+};


### PR DESCRIPTION
## Summary
- add `utils/markdown_utils.js` with helpers for parsing front matter and auto indexes
- refactor `memory.js` to use these helpers
- reuse `parseFrontMatter` in `tools/memory_migrator.js`

## Testing
- `npm test` *(fails: index consistency)*

------
https://chatgpt.com/codex/tasks/task_e_685ea29c92ac8323a1b9f4aa40aac8a2