### PR TITLE
Refactor tools to async file operations

### DIFF
--- a/logic/index_manager.js
+++ b/logic/index_manager.js
@@ -352,7 +352,7 @@ async function saveIndex(token, repo, userId) {
 
   const root = index_tree.loadRoot();
   if (!root || !Array.isArray(root.branches)) return;
-  root.branches.forEach(b => {
+  for (const b of root.branches) {
     const dir = b.path.replace(/\/index\.json$/, '');
     const branchEntries = indexData.filter(e =>
       e.path.replace(/^memory\//, '').startsWith(dir)
@@ -371,11 +371,11 @@ async function saveIndex(token, repo, userId) {
       JSON.stringify({ type: 'index-branch', category: b.category, files }, null, 2),
       'utf-8'
     );
-    checkAndSplitIndex(
+    await checkAndSplitIndex(
       abs,
       indexSettings.max_index_size || 100 * 1024
     );
-  });
+  }
   return { saved: true };
 }
 

--- a/logic/memory_operations.js
+++ b/logic/memory_operations.js
@@ -166,7 +166,7 @@ async function updatePlan({ token, repo, updateFn, userId } = {}) {
   const relPath = 'memory/plan.md';
   const absPath = path.join(path.join(__dirname, '..'), relPath);
 
-  const { repo: finalRepo, token: finalToken } = getRepoInfo(relPath, userId, repo, token);
+  const { repo: finalRepo, token: finalToken } = await getRepoInfo(relPath, userId, repo, token);
 
   let md = '';
   if (finalRepo && finalToken) {
@@ -584,8 +584,8 @@ async function persistIndex(data, repo, token, userId) {
     console.error('[persistIndex] local write error', e.message);
   }
 
-  const finalRepo = repo || (userId ? memory_config.getRepoUrl(userId) : memory_config.getRepoUrl());
-  const finalToken = token || (userId ? token_store.getToken(userId) : null);
+  const finalRepo = repo || (userId ? await memory_config.getRepoUrl(userId) : await memory_config.getRepoUrl());
+  const finalToken = token || (userId ? await token_store.getToken(userId) : null);
 
   if (finalRepo && finalToken) {
     try {

--- a/logic/storage.js
+++ b/logic/storage.js
@@ -23,8 +23,8 @@ function count_tokens(text = '') {
 async function read_memory(user_id, repo, token, filename, opts = {}) {
   const normalized = normalize_memory_path(filename);
   const parse_json = opts.parseJson || false;
-  const finalRepo = repo || memory_config.getRepoUrl(user_id);
-  const finalToken = token || token_store.getToken(user_id);
+  const finalRepo = repo || (await memory_config.getRepoUrl(user_id));
+  const finalToken = token || (await token_store.getToken(user_id));
 
   const masked = finalToken ? `${finalToken.slice(0, 4)}...` : 'null';
   console.log('[read_memory] repo:', finalRepo);
@@ -63,8 +63,8 @@ async function read_memory(user_id, repo, token, filename, opts = {}) {
 
 async function save_memory(user_id, repo, token, filename, content) {
   const normalized = normalize_memory_path(filename);
-  const finalRepo = repo || memory_config.getRepoUrl(user_id);
-  const finalToken = token || token_store.getToken(user_id);
+  const finalRepo = repo || (await memory_config.getRepoUrl(user_id));
+  const finalToken = token || (await token_store.getToken(user_id));
   const masked = finalToken ? `${finalToken.slice(0, 4)}...` : 'null';
   console.log('[save_memory] repo:', finalRepo);
   console.log('[save_memory] token:', masked);
@@ -102,8 +102,8 @@ async function save_memory(user_id, repo, token, filename, content) {
       console.error(`[storage.saveMemory] GitHub write failed for ${normalized}`, e.message);
     }
   }
-  touchIndexEntry(normalized);
-  incrementEditCount(normalized);
+  await touchIndexEntry(normalized);
+  await incrementEditCount(normalized);
   return normalized;
 }
 

--- a/tests/autocontext_index.test.js
+++ b/tests/autocontext_index.test.js
@@ -6,7 +6,7 @@ const { load_context_from_index, setMemoryRepo } = require('../memory');
 const { contextFilename } = require('../logic/memory_operations');
 
 async function run() {
-  setMemoryRepo(null, null);
+  await setMemoryRepo(null, null);
   const idx_rel = 'memory/context/autocontext-index-test.md';
   const idx_abs = path.join(__dirname, '..', idx_rel);
 

--- a/tests/check_and_restore_context.test.js
+++ b/tests/check_and_restore_context.test.js
@@ -4,7 +4,7 @@ const { checkAndRestoreContext, setMemoryRepo } = require('../memory');
 const context_state = require('../tools/context_state');
 
 async function run() {
-  setMemoryRepo(null, null);
+  await setMemoryRepo(null, null);
   context_state.reset_tokens();
 
   await checkAndRestoreContext('theory', 50);

--- a/tests/context_recovery.test.js
+++ b/tests/context_recovery.test.js
@@ -6,7 +6,7 @@ const { auto_recover_context, load_memory_to_context, setMemoryRepo } = require(
 const { contextFilename } = require('../logic/memory_operations');
 
 async function run() {
-  setMemoryRepo(null, null);
+  await setMemoryRepo(null, null);
   const rel = 'memory/lessons/tmp_recover.md';
   const abs = path.join(__dirname, '..', rel);
   const data = ['---','context_priority: high','---','Temp'].join('\n');

--- a/tests/index_splitter.test.js
+++ b/tests/index_splitter.test.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const { checkAndSplitIndex } = require('../tools/index_splitter');
 const index_tree = require('../tools/index_tree');
 
-(function run(){
+(async function run(){
   const idxPath = path.join(__dirname, '..', 'memory', 'drafts', 'index.json');
   const original = fs.readFileSync(idxPath, 'utf-8');
   const data = JSON.parse(original);
@@ -14,7 +14,7 @@ const index_tree = require('../tools/index_tree');
   }
   fs.writeFileSync(idxPath, JSON.stringify(data, null, 2), 'utf-8');
 
-  checkAndSplitIndex(idxPath, 1000);
+  await checkAndSplitIndex(idxPath, 1000);
   const part = path.join(__dirname, '..', 'memory', 'drafts', 'index.part2.json');
   assert.ok(fs.existsSync(part), 'part index created');
   const entries = index_tree.loadBranch('drafts');

--- a/tests/memory_functions.test.js
+++ b/tests/memory_functions.test.js
@@ -7,9 +7,10 @@ const token_store = require('../tools/token_store');
 const memory_config = require('../tools/memory_config');
 
 // ensure no remote repo/token to avoid network operations
-setMemoryRepo(null, null);
+
 
 async function run() {
+  await setMemoryRepo(null, null);
   const index_raw = await readMemory(null, null, 'memory/index.json');
   const index = JSON.parse(index_raw);
   assert.strictEqual(index.type, 'index-root');
@@ -70,20 +71,20 @@ async function run() {
   assert.ok(lesson_read.includes('Edit B'));
   console.log('lesson edit ok');
 
-  setMemoryRepo('tok', 'repo');
-  assert.strictEqual(token_store.getToken(null), 'tok');
-  assert.strictEqual(memory_config.getRepoUrl(null), 'repo');
+  await setMemoryRepo('tok', 'repo');
+  assert.strictEqual(await token_store.getToken(null), 'tok');
+  assert.strictEqual(await memory_config.getRepoUrl(null), 'repo');
   console.log('setMemoryRepo ok');
 
   // disable network writes for cleanup
-  setMemoryRepo(null, null);
+  await setMemoryRepo(null, null);
 
   await saveMemory(null, null, lesson_rel, original_lesson);
   await saveMemory(null, null, checklist_rel, original_checklist);
   fs.rmSync(path.join(__dirname, '..', 'memory/tmp_memory'), { recursive: true, force: true });
 
   // final cleanup
-  setMemoryRepo(null, null);
+  await setMemoryRepo(null, null);
 
   console.log('memory functions tests passed');
 }

--- a/tests/token_counter.test.js
+++ b/tests/token_counter.test.js
@@ -4,7 +4,7 @@ const { setMemoryRepo, checkAndRestoreContext, getTokenCounter, formatTokenCount
 const context_state = require('../tools/context_state');
 
 async function run() {
-  setMemoryRepo(null, null);
+  await setMemoryRepo(null, null);
   context_state.reset_tokens();
   context_state.set_needs_refresh(false);
 

--- a/tools/memory_config.js
+++ b/tools/memory_config.js
@@ -1,61 +1,63 @@
 // Сохраняем и читаем адреса репозиториев для пользователей
 const fs = require('fs');
+const fsp = fs.promises;
 const path = require('path');
 
 const cacheDir = path.join(__dirname, '.cache');
 const reposDir = path.join(cacheDir, 'repos');
 const repoCache = {};
 
-function ensure_dir() {
-  if (!fs.existsSync(reposDir)) {
-    fs.mkdirSync(reposDir, { recursive: true });
-  }
+async function ensure_dir() {
+  try {
+    await fsp.mkdir(reposDir, { recursive: true });
+  } catch {}
 }
 
 function repoPath(userId) {
   return path.join(reposDir, `${userId}.txt`);
 }
 
-function loadRepo(userId) {
+async function loadRepo(userId) {
   if (Object.prototype.hasOwnProperty.call(repoCache, userId)) {
     return repoCache[userId];
   }
   const file = repoPath(userId);
-  if (fs.existsSync(file)) {
-    try {
-      const data = fs.readFileSync(file, 'utf-8').trim();
-      repoCache[userId] = data || null;
-    } catch (e) {
-      repoCache[userId] = null;
-    }
-  } else {
+  try {
+    const data = await fsp.readFile(file, 'utf-8');
+    repoCache[userId] = data.trim() || null;
+  } catch {
     repoCache[userId] = null;
   }
   return repoCache[userId];
 }
 
-function saveRepo(userId, url) {
-  ensure_dir();
+async function saveRepo(userId, url) {
+  await ensure_dir();
   const file = repoPath(userId);
   try {
     if (url) {
-      fs.writeFileSync(file, url, 'utf-8');
-    } else if (fs.existsSync(file)) {
-      fs.unlinkSync(file);
+      await fsp.writeFile(file, url, 'utf-8');
+    } else {
+      await fsp.unlink(file).catch(() => {});
     }
   } catch (e) {
     console.error(`[memoryConfig] failed to save repo url for ${userId}`, e.message);
   }
 }
 
-exports.setRepoUrl = (userId, url) => {
+exports.setRepoUrl = async (userId, url) => {
   repoCache[userId] = url || null;
-  saveRepo(userId, url);
+  await saveRepo(userId, url);
 };
 
 exports.getRepoUrl = userId => loadRepo(userId);
 
-exports.getAllUsers = () => {
-  if (!fs.existsSync(reposDir)) return [];
-  return fs.readdirSync(reposDir).map(f => path.basename(f, '.txt'));
+exports.getAllUsers = async () => {
+  try {
+    await fsp.access(reposDir);
+  } catch {
+    return [];
+  }
+  const files = await fsp.readdir(reposDir);
+  return files.map(f => path.basename(f, '.txt'));
 };

--- a/tools/memory_helpers.js
+++ b/tools/memory_helpers.js
@@ -12,7 +12,7 @@ function logDebug(...args) {
   if (DEBUG) console.log(...args);
 }
 
-function getRepoInfo(relPath, userId, repoOverride, tokenOverride) {
+async function getRepoInfo(relPath, userId, repoOverride, tokenOverride) {
   const normalized = normalize_memory_path(relPath);
   const cfg = rootConfig.loadConfig();
   let repo = repoOverride || null;
@@ -27,19 +27,19 @@ function getRepoInfo(relPath, userId, repoOverride, tokenOverride) {
       console.log(`[repoSelect] ${usePlugin ? 'plugin' : 'student'} -> ${repo}`);
   }
 
-  if (!repo) repo = memory_config.getRepoUrl(userId);
-  if (!token) token = token_store.getToken(userId);
+  if (!repo) repo = await memory_config.getRepoUrl(userId);
+  if (!token) token = await token_store.getToken(userId);
 
   return { repo, token };
 }
 
-function extractToken(req) {
+async function extractToken(req) {
   if (req.body && req.body.token) return req.body.token;
   const auth = req.headers['authorization'];
   if (auth && auth.startsWith('token ')) return auth.slice(6);
   const userId = (req.body && req.body.userId) || null;
   if (userId) {
-    const stored = token_store.getToken(userId);
+    const stored = await token_store.getToken(userId);
     if (stored) return stored;
   }
   return null;

--- a/tools/utils.js
+++ b/tools/utils.js
@@ -13,7 +13,7 @@ const memory_config = require('./memory_config');
  * @returns {{userId: string, repo: string, token: string}|null}
  */
 // Разбор команды настройки памяти пользователя
-function parse_user_memory_setup(message = '') {
+async function parse_user_memory_setup(message = '') {
   if (typeof message !== 'string') return null;
 
   const userMatch = message.match(/(?:for|user)\s+([\w_]+)/i);
@@ -39,8 +39,8 @@ function parse_user_memory_setup(message = '') {
     return null;
   }
 
-  token_store.setToken(userId, token);
-  memory_config.setRepoUrl(userId, repo);
+  await token_store.setToken(userId, token);
+  await memory_config.setRepoUrl(userId, repo);
   console.log(`[MemorySetup] Configured user: ${userId}`);
 
   return { userId, repo, token };


### PR DESCRIPTION
## Summary
- refactor context priority helper for async fs use
- refactor memory config and token store modules
- refactor index splitter to async API
- update memory helpers and dependent modules
- adjust tests for promise-based functions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ea6ad8ce4832381e9ea9d561c4162