### PR TITLE
Fix index updates to use safe path

### DIFF
--- a/logic/memory_operations.js
+++ b/logic/memory_operations.js
@@ -464,7 +464,7 @@ async function loadIndex() {
   } catch {
     console.warn('[loadIndex] index.json not found - creating new');
     ensure_dir(indexFilename);
-    await writeFileSafe(indexFilename, '[]');
+    await fsp.writeFile(indexFilename, '[]');
     return [];
   }
 
@@ -473,7 +473,7 @@ async function loadIndex() {
     return Array.isArray(parsed) ? parsed : [];
   } catch (e) {
     console.warn('[loadIndex] failed to parse index.json, resetting', e.message);
-    await writeFileSafe(indexFilename, '[]');
+    await fsp.writeFile(indexFilename, '[]');
     return [];
   }
 }
@@ -621,7 +621,7 @@ async function persistIndex(data, repo, token, userId) {
         await safeUpdateIndexEntry(entry);
       }
     } else {
-      await writeFileSafe(indexFilename, JSON.stringify(payload, null, 2));
+      await fsp.writeFile(indexFilename, JSON.stringify(payload, null, 2));
     }
     console.log('[persistIndex] local index saved');
   } catch (e) {


### PR DESCRIPTION
## Summary
- prevent duplicates by always using `safeUpdateIndexEntry` when modifying index
- stop using `writeFileSafe(indexFilename, ...)` in favor of direct fs writes

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68602a715c58832386638712fcbe9a51