### PR TITLE
fix: log loaded context files

### DIFF
--- a/logic/index_manager.js
+++ b/logic/index_manager.js
@@ -254,9 +254,7 @@ async function loadIndex() {
       .filter(e => ['high', 'medium'].includes(e.context_priority || 'medium'))
       .slice(0, maxFiles);
     indexData.forEach(entry =>
-      console.log(
-        `[CTX] Загружается файл: ${entry.file}, приоритет: ${entry.context_priority}`
-      )
+      console.log(`[CTX] Загружается файл: ${entry.file}, приоритет: ${entry.context_priority}`)
     );
     if (
       indexSettings.validate_on_load &&


### PR DESCRIPTION
## Summary
- log each loaded context file on a single line in `index_manager.js`

## Testing
- `npm test` *(fails: missing repo state)*

------
https://chatgpt.com/codex/tasks/task_e_68604515c43083239c6bdd871eedc67c