### PR TITLE
Add tag matching helper

### DIFF
--- a/logic/index_manager.js
+++ b/logic/index_manager.js
@@ -11,7 +11,7 @@ const {
   inferTypeFromPath
 } = require('../tools/file_utils');
 const { logError } = require('../tools/error_handler');
-const { sort_by_priority } = require('../tools/index_utils');
+const { sort_by_priority, hasMatchingTag } = require('../tools/index_utils');
 const index_tree = require('../tools/index_tree');
 const { indexSettings, validateIndex } = require('./index_validator');
 const { checkAndSplitIndex } = require('../tools/index_splitter');
@@ -139,7 +139,7 @@ function getByPath(p) {
 }
 
 function getByTag(tag) {
-  return loadIndexSync().filter(e => Array.isArray(e.tags) && e.tags.includes(tag));
+  return loadIndexSync().filter(e => hasMatchingTag(e, tag));
 }
 
 function filterByStatus(status) {
@@ -148,9 +148,7 @@ function filterByStatus(status) {
 
 function filterByTags(tags) {
   const arr = Array.isArray(tags) ? tags : [tags];
-  return loadIndexSync().filter(
-    e => Array.isArray(e.tags) && arr.every(t => e.tags.includes(t))
-  );
+  return loadIndexSync().filter(e => arr.every(t => hasMatchingTag(e, t)));
 }
 
 function filterByDate(field, days) {

--- a/tools/index_utils.js
+++ b/tools/index_utils.js
@@ -76,4 +76,15 @@ function sort_by_priority(arr) {
   });
 }
 
-module.exports = { index_to_array, array_to_index, sort_by_priority };
+function hasMatchingTag(entry, queryTag) {
+  const tags = Array.isArray(entry.tags) ? entry.tags : [];
+  const aliases = Array.isArray(entry.aliases) ? entry.aliases : [];
+  return [...tags, ...aliases].includes(queryTag);
+}
+
+module.exports = {
+  index_to_array,
+  array_to_index,
+  sort_by_priority,
+  hasMatchingTag
+};


### PR DESCRIPTION
## Summary
- add `hasMatchingTag` in `index_utils`
- use the new helper in `index_manager`

## Testing
- `npm test` *(fails: Command failed: node tests/move_file_update_index.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68604ae384b88323ae8158323ce0f7b8