### PR TITLE
Add MIN_TOKENS check in split_memory_file

### DIFF
--- a/tools/memory_splitter.js
+++ b/tools/memory_splitter.js
@@ -3,6 +3,8 @@ const path = require('path');
 const index_manager = require('../logic/index_manager');
 const { ensure_dir, normalize_memory_path } = require('./file_utils');
 
+const MIN_TOKENS = 30; // minimum tokens per part to avoid tiny fragments
+
 function count_tokens(text = '') {
   return String(text).split(/\s+/).filter(Boolean).length;
 }
@@ -97,7 +99,9 @@ async function split_memory_file(filename, max_tokens) {
   };
   blocks.forEach(b => {
     const t = count_tokens(b);
-    if (buf.length && tok + t > max_tokens) flush();
+    if (buf.length && tok + t > max_tokens) {
+      if (tok >= MIN_TOKENS) flush();
+    }
     buf.push(b);
     tok += t;
   });


### PR DESCRIPTION
## Summary
- prevent tiny memory fragments by requiring at least 30 tokens per split

## Testing
- `npm test` *(fails: AssertionError: The expression evaluated to a falsy value)*
- `node tests/memory_split.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68605048336c8323939f0512dde8f76a