### PR TITLE
Add split-part tag to generated memory parts

### DIFF
--- a/tools/memory_splitter.js
+++ b/tools/memory_splitter.js
@@ -109,7 +109,14 @@ async function split_memory_file(filename, max_tokens) {
 
   parts.forEach((p, idx) => {
     const part_path = path.join(dir, `part${idx + 1}.md`);
-    fs.writeFileSync(part_path, p + '\n', 'utf-8');
+    const meta = [
+      '---',
+      `part_index: ${idx + 1}`,
+      'tag: split-part',
+      '---',
+      ''
+    ].join('\n');
+    fs.writeFileSync(part_path, meta + p + '\n', 'utf-8');
   });
 
   const title_match = original.match(/^#\s*(.+)/);


### PR DESCRIPTION
## Summary
- add a split-part tag to files generated by memory_splitter

## Testing
- `npm install`
- `npm test` *(fails: git pull and missing files in tests)*

------
https://chatgpt.com/codex/tasks/task_e_686054302a1083238d0324529578f463