### PR TITLE
Replace token counter with estimate_cost

### DIFF
--- a/logic/markdown_editor.js
+++ b/logic/markdown_editor.js
@@ -2,9 +2,10 @@ const fs = require('fs');
 const path = require('path');
 const validator = require('./markdown_validator');
 const memory_settings = require('../tools/memory_settings');
+const { estimate_cost } = require('../tools/text_utils');
 
 function count_tokens(text = '') {
-  return String(text).split(/\s+/).filter(Boolean).length;
+  return estimate_cost(text, 'tokens');
 }
 
 function createBackup(filePath) {
@@ -64,7 +65,7 @@ function writeLines(filePath, lines, force = false) {
   }
   createBackup(filePath);
   const data = Array.isArray(lines) ? lines.join('\n') : lines;
-  const tokens = count_tokens(data);
+  const tokens = estimate_cost(data, 'tokens');
   if (tokens > memory_settings.token_soft_limit && memory_settings.enforce_soft_limit) {
     console.warn('[writeLines] token limit reached', tokens);
     return false;

--- a/src/storage.js
+++ b/src/storage.js
@@ -15,9 +15,10 @@ const {
 const { split_memory_file } = require('../tools/memory_splitter');
 const { logError } = require('../tools/error_handler');
 const memory_settings = require('../tools/memory_settings');
+const { estimate_cost } = require('../tools/text_utils');
 
 function count_tokens(text = '') {
-  return String(text).split(/\s+/).filter(Boolean).length;
+  return estimate_cost(text, 'tokens');
 }
 
 async function read_memory(user_id, repo, token, filename, opts = {}) {
@@ -69,7 +70,7 @@ async function save_memory(user_id, repo, token, filename, content) {
   console.log('[save_memory] repo:', finalRepo);
   console.log('[save_memory] token:', masked);
   console.log('[save_memory] file:', normalized);
-  const tokens = count_tokens(content);
+  const tokens = estimate_cost(content, 'tokens');
   if (tokens > memory_settings.token_soft_limit) {
     console.warn('[save_memory] token limit reached', tokens);
     if (memory_settings.enforce_soft_limit) {
@@ -115,7 +116,7 @@ async function save_memory_with_index(user_id, repo, token, filename, content) {
   const check = await index_manager.validateFilePathAgainstIndex(filename);
   if (check.warning) console.warn(`[index] ${check.warning}`);
   const finalPath = check.expectedPath || filename;
-  const tokens = count_tokens(content);
+  const tokens = estimate_cost(content, 'tokens');
   if (tokens > memory_settings.token_soft_limit) {
     console.warn('[save_memory_with_index] token limit reached', tokens);
     if (memory_settings.enforce_soft_limit) {

--- a/tools/memory_splitter.js
+++ b/tools/memory_splitter.js
@@ -2,11 +2,12 @@ const fs = require('fs');
 const path = require('path');
 const index_manager = require('../logic/index_manager');
 const { ensure_dir, normalize_memory_path } = require('./file_utils');
+const { estimate_cost } = require('./text_utils');
 
 const MIN_TOKENS = 30; // minimum tokens per part to avoid tiny fragments
 
 function count_tokens(text = '') {
-  return String(text).split(/\s+/).filter(Boolean).length;
+  return estimate_cost(text, 'tokens');
 }
 
 function split_into_blocks(md) {
@@ -83,7 +84,7 @@ async function split_memory_file(filename, max_tokens) {
     return out;
   }
 
-  const total_tokens = count_tokens(content);
+  const total_tokens = estimate_cost(content, 'tokens');
   if (total_tokens <= max_tokens) return [normalized];
 
   const dir = is_index ? path.dirname(abs) : abs.replace(/\.md$/i, '');
@@ -103,7 +104,7 @@ async function split_memory_file(filename, max_tokens) {
     tok = 0;
   };
   blocks.forEach(b => {
-    const t = count_tokens(b);
+    const t = estimate_cost(b, 'tokens');
     if (buf.length && tok + t > max_tokens) {
       if (tok >= MIN_TOKENS) flush();
     }


### PR DESCRIPTION
## Summary
- import `estimate_cost` utility
- replace calls to `count_tokens` with `estimate_cost`

## Testing
- `npm test` *(fails: File not found errors)*

------
https://chatgpt.com/codex/tasks/task_e_6860c8835238832392f3e0c6406b16c4