### PR TITLE
Remove unused count_tokens helpers

### DIFF
--- a/logic/markdown_editor.js
+++ b/logic/markdown_editor.js
@@ -4,10 +4,6 @@ const validator = require('./markdown_validator');
 const memory_settings = require('../tools/memory_settings');
 const { estimate_cost } = require('../tools/text_utils');
 
-function count_tokens(text = '') {
-  return estimate_cost(text, 'tokens');
-}
-
 function createBackup(filePath) {
   if (!fs.existsSync(filePath)) return null;
 

--- a/src/memory.js
+++ b/src/memory.js
@@ -25,10 +25,6 @@ const {
   contextFilename,
 } = require('../logic/memory_operations');
 
-function count_tokens(text = '') {
-  return estimate_cost(text, 'tokens');
-}
-
 function getTokenCounter() {
   const { used, limit } = context_state.get_status();
   const remaining = limit - used;

--- a/src/storage.js
+++ b/src/storage.js
@@ -17,10 +17,6 @@ const { logError } = require('../tools/error_handler');
 const memory_settings = require('../tools/memory_settings');
 const { estimate_cost } = require('../tools/text_utils');
 
-function count_tokens(text = '') {
-  return estimate_cost(text, 'tokens');
-}
-
 async function read_memory(user_id, repo, token, filename, opts = {}) {
   const normalized = normalize_memory_path(filename);
   const parse_json = opts.parseJson || false;

--- a/tools/memory_splitter.js
+++ b/tools/memory_splitter.js
@@ -8,10 +8,6 @@ const COST_MODE = process.env.SOFIA_COST_MODE || 'bytes';
 
 const MIN_TOKENS = 30; // minimum tokens per part to avoid tiny fragments
 
-function count_tokens(text = '') {
-  return estimate_cost(text, COST_MODE);
-}
-
 function split_into_blocks(md) {
   const lines = md.split(/\r?\n/);
   const has_anchor = lines.some(l => /<!--\s*START:/i.test(l));


### PR DESCRIPTION
## Summary
- drop unused `count_tokens` helpers from various modules

## Testing
- `npm test` *(fails: ERR_ASSERTION)*

------
https://chatgpt.com/codex/tasks/task_e_6860cb7fe8b483239c55942dbdf354b4