### PR TITLE
Update rebuildIndex entry defaults

### DIFF
--- a/logic/memory_operations.js
+++ b/logic/memory_operations.js
@@ -794,16 +794,15 @@ async function rebuildIndex(repo, token, userId) {
   for (const rel of paths) {
     const abs = path.join(path.join(__dirname, '..'), rel);
     const meta = await extractMeta(abs);
-    const idx = index_tree.findEntryByPath(rel) || {};
     entries.push({
       path: rel,
       type: categorizeMemoryFile(path.basename(rel)),
       title: meta.title,
       description: meta.description,
+      tags: meta.tags || [],
+      aliases: meta.aliases || [],
+      context_priority: meta.context_priority || 'medium',
       lastModified: meta.lastModified,
-      tags: meta.tags || idx.tags,
-      aliases: meta.aliases || idx.aliases,
-      context_priority: meta.context_priority || idx.context_priority,
     });
   }
 


### PR DESCRIPTION
## Summary
- ensure rebuildIndex adds `tags`, `aliases`, and `context_priority` with default values

## Testing
- `npm test` *(fails: index.findIndex is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6860d19a3e3483238d1770da0d0d8642