### PR TITLE
Add error handling for meta extraction

### DIFF
--- a/logic/memory_operations.js
+++ b/logic/memory_operations.js
@@ -793,17 +793,24 @@ async function rebuildIndex(repo, token, userId) {
   const entries = [];
   for (const rel of paths) {
     const abs = path.join(path.join(__dirname, '..'), rel);
-    const meta = await extractMeta(abs);
-    entries.push({
-      path: rel,
-      type: categorizeMemoryFile(path.basename(rel)),
-      title: meta.title,
-      description: meta.description,
-      tags: meta.tags || [],
-      aliases: meta.aliases || [],
-      context_priority: meta.context_priority || 'medium',
-      lastModified: meta.lastModified,
-    });
+    try {
+      const meta = await extractMeta(abs);
+      entries.push({
+        path: rel,
+        type: categorizeMemoryFile(path.basename(rel)),
+        title: meta.title,
+        description: meta.description,
+        tags: meta.tags || [],
+        aliases: meta.aliases || [],
+        context_priority: meta.context_priority || 'medium',
+        lastModified: meta.lastModified,
+      });
+    } catch (e) {
+      console.warn(
+        `[REBUILD] Не удалось прочитать мета из файла: ${rel}`,
+        e.message,
+      );
+    }
   }
 
   const clean = await sanitizeIndex(deduplicateEntries(entries));


### PR DESCRIPTION
## Summary
- handle `extractMeta` errors when rebuilding index

## Testing
- `npm test` *(fails: `move_file_update_index.test.js` assertion error)*

------
https://chatgpt.com/codex/tasks/task_e_6860d27f66488323a17d560f56292c1b