### PR TITLE
Add root index generation

### DIFF
--- a/logic/memory_operations.js
+++ b/logic/memory_operations.js
@@ -815,6 +815,23 @@ async function rebuildIndex(repo, token, userId) {
 
   const clean = await sanitizeIndex(deduplicateEntries(entries));
   await persistIndex(clean, repo, token, userId);
+
+  const rootIndex = {
+    type: 'index-root',
+    branches: [
+      { category: 'lessons', path: 'lessons/index.json' },
+      { category: 'plans', path: 'plans/index.json' },
+      { category: 'drafts', path: 'drafts/index.json' },
+    ],
+  };
+
+  const base = path.join(__dirname, '..');
+  await fs.promises.writeFile(
+    path.join(base, 'memory', 'index.json'),
+    JSON.stringify(rootIndex, null, 2),
+    'utf-8',
+  );
+
   return clean;
 }
 

--- a/memory/index.json
+++ b/memory/index.json
@@ -1,11 +1,17 @@
 {
   "type": "index-root",
   "branches": [
-    { "category": "context", "path": "plans/context/index.json" },
-    { "category": "structure", "path": "plans/structure/index.json" },
-    { "category": "features", "path": "plans/features/index.json" },
-    { "category": "safety", "path": "plans/safety/index.json" },
-    { "category": "lessons", "path": "lessons/index.json" },
-    { "category": "drafts", "path": "drafts/index.json" }
+    {
+      "category": "lessons",
+      "path": "lessons/index.json"
+    },
+    {
+      "category": "plans",
+      "path": "plans/index.json"
+    },
+    {
+      "category": "drafts",
+      "path": "drafts/index.json"
+    }
   ]
 }

--- a/memory/plans/index.json
+++ b/memory/plans/index.json
@@ -1,0 +1,5 @@
+{
+  "type": "index-branch",
+  "category": "plans",
+  "files": []
+}

--- a/tests/index_save_metadata.test.js
+++ b/tests/index_save_metadata.test.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const index_manager = require('../logic/index_manager');
 
 (async function run() {
-  const idxPath = path.join(__dirname, '..', 'memory', 'plans', 'features', 'index.json');
+  const idxPath = path.join(__dirname, '..', 'memory', 'plans', 'index.json');
   const original = fs.readFileSync(idxPath, 'utf-8');
 
   await index_manager.loadIndex();


### PR DESCRIPTION
## Summary
- add root index creation in `rebuildIndex`
- update root index data
- create a stub `plans/index.json`
- adjust metadata test for new index location

## Testing
- `npm test` *(fails: index.findIndex is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6860d8573c888323a63dd81129b85647