### PR TITLE
Implement updateMarkdownBlock utility

### DIFF
--- a/tests/updateMarkdownBlock.test.js
+++ b/tests/updateMarkdownBlock.test.js
@@ -1,0 +1,21 @@
+const assert = require('assert');
+const { updateMarkdownBlock } = require('../utils/markdown_utils');
+
+(function run(){
+  const src = [
+    '# Title',
+    '<!-- START: plan -->',
+    'old text',
+    '<!-- END: plan -->'
+  ].join('\n');
+
+  const replaced = updateMarkdownBlock(src, 'plan', 'new text');
+  assert.ok(replaced.includes('new text'));
+  assert.ok(!replaced.includes('old text'));
+
+  const added = updateMarkdownBlock('# One', 'extra', 'block');
+  assert.ok(added.includes('<!-- START: extra -->'));
+  assert.ok(added.trim().endsWith('<!-- END: extra -->'));
+
+  console.log('updateMarkdownBlock tests passed');
+})();

--- a/utils/markdown_utils.js
+++ b/utils/markdown_utils.js
@@ -107,8 +107,26 @@ function parseMarkdownSections(fileContent = '') {
   return blocks;
 }
 
+function updateMarkdownBlock(fileContent = '', tag = '', newContent = '') {
+  const startMarker = `<!-- START: ${tag} -->`;
+  const endMarker = `<!-- END: ${tag} -->`;
+  const startIdx = fileContent.indexOf(startMarker);
+  const endIdx = fileContent.indexOf(endMarker);
+
+  if (startIdx === -1 || endIdx === -1 || endIdx < startIdx) {
+    const trimmed = fileContent.replace(/\s*$/, '');
+    const nl = trimmed ? '\n' : '';
+    return `${trimmed}${nl}${startMarker}\n${newContent}\n${endMarker}\n`;
+  }
+
+  const before = fileContent.slice(0, startIdx + startMarker.length);
+  const after = fileContent.slice(endIdx);
+  return `${before}\n${newContent}\n${after}`;
+}
+
 module.exports = {
   parseFrontMatter,
   parseAutoIndex,
   parseMarkdownSections,
+  updateMarkdownBlock,
 };


### PR DESCRIPTION
## Summary
- add `updateMarkdownBlock` helper in `utils/markdown_utils.js`
- export the new helper
- test updating or adding markdown blocks

## Testing
- `npm test` *(fails: assert error)*

------
https://chatgpt.com/codex/tasks/task_e_6860e52c9460832384aeed89d7028074