### PR TITLE
Implement deduplicateTasks utility

### DIFF
--- a/tests/deduplicate_tasks.test.js
+++ b/tests/deduplicate_tasks.test.js
@@ -1,0 +1,10 @@
+const assert = require('assert');
+const { deduplicateTasks } = require('../utils/markdown_utils');
+
+(function run(){
+  const existing = ['- [x] Добавить поддержку index.json'];
+  const newer = ['- [ ] Добавить поддержку index.json', '- [ ] Новая задача'];
+  const result = deduplicateTasks(existing, newer);
+  assert.deepStrictEqual(result, ['- [ ] Новая задача']);
+  console.log('deduplicateTasks test passed');
+})();

--- a/utils/markdown_utils.js
+++ b/utils/markdown_utils.js
@@ -124,9 +124,21 @@ function updateMarkdownBlock(fileContent = '', tag = '', newContent = '') {
   return `${before}\n${newContent}\n${after}`;
 }
 
+function deduplicateTasks(existingLines = [], newLines = []) {
+  const normalize = line =>
+    String(line)
+      .replace(/^\s*[-*]\s+\[[ xX]\]\s*/, '')
+      .replace(/\s+/g, '')
+      .toLowerCase();
+
+  const existingSet = new Set(existingLines.map(normalize));
+  return newLines.filter(l => !existingSet.has(normalize(l)));
+}
+
 module.exports = {
   parseFrontMatter,
   parseAutoIndex,
   parseMarkdownSections,
   updateMarkdownBlock,
+  deduplicateTasks,
 };


### PR DESCRIPTION
## Summary
- add `deduplicateTasks` helper in `markdown_utils`
- provide tests for `deduplicateTasks`

## Testing
- `node tests/deduplicate_tasks.test.js`
- `npm test` *(fails: index.findIndex is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6860e6b756f8832394e4a9e180338019