### PR TITLE
Add safe checklist update helper

### DIFF
--- a/tests/safeUpdateMarkdownChecklist.test.js
+++ b/tests/safeUpdateMarkdownChecklist.test.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const { safeUpdateMarkdownChecklist } = require('../utils/markdown_utils');
+
+const tmpDir = path.join(__dirname, 'tmp_safe_update');
+if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir);
+
+(function run(){
+  const file = path.join(tmpDir, 'list.md');
+  const initial = [
+    '# Tasks',
+    '',
+    '<!-- START: todo -->',
+    '- [ ] a',
+    '- [ ] b',
+    '<!-- END: todo -->',
+    ''
+  ].join('\n');
+  fs.writeFileSync(file, initial);
+
+  safeUpdateMarkdownChecklist(file, 'todo', ['- [ ] c', '- [ ] a']);
+  let text = fs.readFileSync(file, 'utf-8');
+  assert.strictEqual((text.match(/- \[ \] a/g) || []).length, 1);
+  assert.strictEqual((text.match(/- \[ \] b/g) || []).length, 1);
+  assert.strictEqual((text.match(/- \[ \] c/g) || []).length, 1);
+
+  safeUpdateMarkdownChecklist(file, 'todo', ['- [ ] c']);
+  text = fs.readFileSync(file, 'utf-8');
+  assert.strictEqual((text.match(/- \[ \] c/g) || []).length, 1);
+
+  console.log('safeUpdateMarkdownChecklist test passed');
+})();


### PR DESCRIPTION
## Summary
- implement `safeUpdateMarkdownChecklist` for deduplication and update
- test checklist update helper

## Testing
- `node tests/safeUpdateMarkdownChecklist.test.js`
- `npm test` *(fails: index.findIndex is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6860e7e8ba9c8323a0364e8280bd5377