### PR TITLE
Add missing block helper

### DIFF
--- a/memory/plan_checklist.md
+++ b/memory/plan_checklist.md
@@ -10,3 +10,7 @@
   - Global instructions (in plugin, read-only)
   - Individual instructions (in student repository with versioning)
   - Support backup mode, commands and change history
+
+<!-- START: tag -->
+<!-- created: 2025-06-29 -->
+<!-- END: tag -->

--- a/tests/autocreate_block.test.js
+++ b/tests/autocreate_block.test.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const { ensureMarkdownBlock } = require('../utils/markdown_utils');
+
+const tmpDir = path.join(__dirname, 'tmp_autocreate');
+if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir);
+
+(function run(){
+  const file = path.join(tmpDir, 'check.md');
+  fs.writeFileSync(file, '# Title\n');
+  ensureMarkdownBlock(file, 'tag', '- [ ] item', { created: '2025-06-29' });
+  const text = fs.readFileSync(file, 'utf-8');
+  assert.ok(text.includes('<!-- START: tag -->'));
+  assert.ok(text.includes('<!-- END: tag -->'));
+  assert.ok(text.includes('<!-- created: 2025-06-29 -->'));
+  console.log('autocreate block test passed');
+})();

--- a/utils/markdown_utils.js
+++ b/utils/markdown_utils.js
@@ -182,6 +182,27 @@ function safeUpdateMarkdownChecklist(filePath, tag, newLines = []) {
   return true;
 }
 
+function ensureMarkdownBlock(filePath, tag, content = '', opts = {}) {
+  const fs = require('fs');
+  const raw = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf-8') : '';
+  const startMarker = `<!-- START: ${tag} -->`;
+  const endMarker = `<!-- END: ${tag} -->`;
+
+  if (raw.includes(startMarker) && raw.includes(endMarker)) return false;
+
+  const timestamp = opts.created
+    ? opts.created
+    : opts.addTimestamp
+    ? new Date().toISOString().slice(0, 10)
+    : null;
+  const lines = [];
+  if (content) lines.push(content);
+  if (timestamp) lines.push(`<!-- created: ${timestamp} -->`);
+  const updated = updateMarkdownBlock(raw, tag, lines.join('\n'));
+  fs.writeFileSync(filePath, updated, 'utf-8');
+  return true;
+}
+
 module.exports = {
   parseFrontMatter,
   parseAutoIndex,
@@ -189,4 +210,5 @@ module.exports = {
   updateMarkdownBlock,
   deduplicateTasks,
   safeUpdateMarkdownChecklist,
+  ensureMarkdownBlock,
 };


### PR DESCRIPTION
## Summary
- implement `ensureMarkdownBlock` to auto-create anchor sections
- add checklist block example with creation date
- add tests for block auto creation

## Testing
- `npm test` *(fails: index.findIndex is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6860e9b87344832381c9b26a20c00c91