### PR TITLE
Implement safeUpdateMarkdownChecklist

### DIFF
--- a/tests/markdown_utils.test.js
+++ b/tests/markdown_utils.test.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const { safeUpdateMarkdownChecklist } = require('../utils/markdown_utils');
+
+const tmpDir = path.join(__dirname, 'tmp_md_utils');
+if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir);
+
+(async function run(){
+  const file = path.join(tmpDir, 'list.md');
+  if (fs.existsSync(file)) fs.unlinkSync(file);
+
+  // create new file with one task
+  await safeUpdateMarkdownChecklist(file, 'todo', ['- [ ] one']);
+  let text = fs.readFileSync(file, 'utf-8');
+  assert.ok(text.includes('- [ ] one'), 'task written');
+
+  // update existing block with additional task and duplicate
+  await safeUpdateMarkdownChecklist(file, 'todo', ['- [ ] two', '- [ ] one']);
+  text = fs.readFileSync(file, 'utf-8');
+  assert.ok(text.includes('- [ ] two'), 'new task added');
+  assert.strictEqual((text.match(/- \[ \] one/g) || []).length, 1, 'no duplicate');
+
+  console.log('markdown_utils safe update tests passed');
+})();


### PR DESCRIPTION
## Summary
- add an async `safeUpdateMarkdownChecklist` that reads/writes markdown checklists safely
- include new test `markdown_utils.test.js`

## Testing
- `node tests/markdown_utils.test.js`
- `node tests/safeUpdateMarkdownChecklist.test.js`
- `npm test` *(fails: git operations & index schema validation)*

------
https://chatgpt.com/codex/tasks/task_e_6860ee6b8e4c8323a9053aaed99ee187