### PR TITLE
Add checklist status merging

### DIFF
--- a/tests/markdown_utils.test.js
+++ b/tests/markdown_utils.test.js
@@ -21,5 +21,13 @@ if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir);
   assert.ok(text.includes('- [ ] two'), 'new task added');
   assert.strictEqual((text.match(/- \[ \] one/g) || []).length, 1, 'no duplicate');
 
+  // change status and revert
+  await safeUpdateMarkdownChecklist(file, 'todo', ['- [x] two']);
+  text = fs.readFileSync(file, 'utf-8');
+  assert.ok(text.includes('- [x] two'), 'status updated');
+  await safeUpdateMarkdownChecklist(file, 'todo', ['- [ ] two']);
+  text = fs.readFileSync(file, 'utf-8');
+  assert.ok(text.includes('- [ ] two'), 'status reverted');
+
   console.log('markdown_utils safe update tests passed');
 })();

--- a/tests/safeUpdateMarkdownChecklist.test.js
+++ b/tests/safeUpdateMarkdownChecklist.test.js
@@ -29,5 +29,17 @@ if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir);
   text = fs.readFileSync(file, 'utf-8');
   assert.strictEqual((text.match(/- \[ \] c/g) || []).length, 1);
 
+  // update status of existing task
+  safeUpdateMarkdownChecklist(file, 'todo', ['- [x] b']);
+  text = fs.readFileSync(file, 'utf-8');
+  assert.strictEqual((text.match(/- \[x\] b/g) || []).length, 1);
+  assert.strictEqual((text.match(/- \[ \] b/g) || []).length, 0);
+
+  // revert status
+  safeUpdateMarkdownChecklist(file, 'todo', ['- [ ] b']);
+  text = fs.readFileSync(file, 'utf-8');
+  assert.strictEqual((text.match(/- \[ \] b/g) || []).length, 1);
+  assert.strictEqual((text.match(/- \[x\] b/g) || []).length, 0);
+
   console.log('safeUpdateMarkdownChecklist test passed');
 })();


### PR DESCRIPTION
## Summary
- extend markdown utility with `mergeTaskLines` to handle status updates
- modify `safeUpdateMarkdownChecklist` to use new merge logic
- export `mergeTaskLines`
- update related tests to verify status updates

## Testing
- `node tests/safeUpdateMarkdownChecklist.test.js && node tests/markdown_utils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6860fa5e36988323911176cacbb84473