### PR TITLE
Add updateIndexFile utility

### DIFF
--- a/tests/index_utils.test.js
+++ b/tests/index_utils.test.js
@@ -1,0 +1,36 @@
+process.env.NO_GIT = "true";
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const { updateIndexFile } = require('../tools/simple_index');
+
+(async function run(){
+  const tmpDir = path.join(__dirname, 'tmp_index');
+  const idxPath = path.join(tmpDir, 'index_lessons.json');
+  if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir, { recursive: true });
+
+  await updateIndexFile(idxPath, { title: 'Lesson A', file: 'a.md', tags: ['a'], priority: 2 });
+  let data = JSON.parse(fs.readFileSync(idxPath, 'utf-8'));
+  assert.strictEqual(data.files.length, 1, 'file created');
+  assert.strictEqual(data.files[0].title, 'Lesson A');
+
+  await updateIndexFile(idxPath, { title: 'Lesson B', file: 'b.md', tags: [], priority: 1 });
+  data = JSON.parse(fs.readFileSync(idxPath, 'utf-8'));
+  assert.strictEqual(data.files.length, 2, 'added entry');
+  assert.strictEqual(data.files[0].file, 'b.md', 'sorted by priority');
+
+  await updateIndexFile(idxPath, { title: 'Lesson B updated', file: 'b.md', tags: ['x'], priority: 3 });
+  data = JSON.parse(fs.readFileSync(idxPath, 'utf-8'));
+  assert.strictEqual(data.files.length, 2, 'no duplicates');
+  const b = data.files.find(e => e.file === 'b.md');
+  assert.strictEqual(b.title, 'Lesson B updated', 'updated title');
+  assert.deepStrictEqual(b.tags, ['x']);
+  assert.strictEqual(b.priority, 3);
+
+  const priorities = data.files.map(e => e.priority);
+  const sorted = [...priorities].sort((a,b)=>(a??Infinity)-(b??Infinity));
+  assert.deepStrictEqual(priorities, sorted, 'sorted by priority');
+
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  console.log('index_utils tests passed');
+})();

--- a/tools/simple_index.js
+++ b/tools/simple_index.js
@@ -1,0 +1,43 @@
+const fs = require('fs').promises;
+const path = require('path');
+
+async function loadIndex(indexPath) {
+  try {
+    const raw = await fs.readFile(indexPath, 'utf-8');
+    const data = JSON.parse(raw);
+    if (!Array.isArray(data.files)) data.files = [];
+    return data;
+  } catch {
+    return { files: [] };
+  }
+}
+
+function sortByPriority(arr) {
+  return arr.slice().sort((a, b) => {
+    const pa = a.priority ?? Infinity;
+    const pb = b.priority ?? Infinity;
+    if (pa === pb) return 0;
+    return pa - pb;
+  });
+}
+
+async function updateIndexFile(indexPath, newEntry) {
+  if (!newEntry || !newEntry.file) return null;
+
+  const data = await loadIndex(indexPath);
+  let updated = false;
+  data.files = data.files.map(e => {
+    if (e.file === newEntry.file) {
+      updated = true;
+      return { ...e, ...newEntry };
+    }
+    return e;
+  });
+  if (!updated) data.files.push(newEntry);
+  data.files = sortByPriority(data.files);
+  await fs.mkdir(path.dirname(indexPath), { recursive: true });
+  await fs.writeFile(indexPath, JSON.stringify(data, null, 2), 'utf-8');
+  return data;
+}
+
+module.exports = { updateIndexFile };


### PR DESCRIPTION
## Summary
- provide `updateIndexFile` helper to manage index_*.json files
- test the helper's behavior for updating, adding, deduplication and sorting

## Testing
- `node tests/index_utils.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6860fdcbbfa083238187375886b936cb