### PR TITLE
Add alias search in memory indices

### DIFF
--- a/logic/index_loader.js
+++ b/logic/index_loader.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+const path = require('path');
+const { findMatchingFile } = require('../tools/index_utils');
+
+function loadIndex(indexPath) {
+  const abs = path.join(__dirname, '..', indexPath);
+  if (!fs.existsSync(abs)) return null;
+  try {
+    const raw = fs.readFileSync(abs, 'utf-8');
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function chooseLesson(keyword, indexPath = 'memory/lessons/index.json') {
+  const data = loadIndex(indexPath);
+  if (!data) return null;
+  const matches = findMatchingFile(data, keyword);
+  return matches[0] || null;
+}
+
+module.exports = { loadIndex, chooseLesson };

--- a/memory/lessons/index.json
+++ b/memory/lessons/index.json
@@ -2,7 +2,21 @@
   "type": "index-branch",
   "category": "lessons",
   "files": [
-    { "title": "Intro Lesson", "file": "lessons/intro.md", "tags": ["intro"], "context_priority": "medium" },
-    { "title": "Example Lesson", "file": "lessons/04_example.md", "tags": [], "context_priority": "high" }
+    {
+      "title": "Example Lesson",
+      "file": "lessons/04_example.md",
+      "tags": [],
+      "aliases": [],
+      "context_priority": "high"
+    },
+    {
+      "title": "Intro Lesson",
+      "file": "lessons/intro.md",
+      "tags": [
+        "intro"
+      ],
+      "aliases": [],
+      "context_priority": "medium"
+    }
   ]
 }

--- a/memory/plans/context/index.json
+++ b/memory/plans/context/index.json
@@ -2,6 +2,12 @@
   "type": "index-branch",
   "category": "context",
   "files": [
-    { "title": "Context Overview", "file": "plans/context/overview.md", "tags": ["context"], "context_priority": "high" }
+    {
+      "title": "Context Overview",
+      "file": "plans/context/overview.md",
+      "tags": ["context"],
+      "aliases": [],
+      "context_priority": "high"
+    }
   ]
 }

--- a/memory/plans/features/index.json
+++ b/memory/plans/features/index.json
@@ -2,7 +2,19 @@
   "type": "index-branch",
   "category": "features",
   "files": [
-    { "title": "Token Limit Guard", "file": "plans/features/limit_guard.md", "tags": ["limits", "token"], "context_priority": "high" },
-    { "title": "Search API", "file": "plans/features/search_api.md", "tags": ["search", "api"], "context_priority": "high" }
+    {
+      "title": "Token Limit Guard",
+      "file": "plans/features/limit_guard.md",
+      "tags": ["limits", "token"],
+      "aliases": [],
+      "context_priority": "high"
+    },
+    {
+      "title": "Search API",
+      "file": "plans/features/search_api.md",
+      "tags": ["search", "api"],
+      "aliases": [],
+      "context_priority": "high"
+    }
   ]
 }

--- a/memory/plans/safety/index.json
+++ b/memory/plans/safety/index.json
@@ -2,6 +2,12 @@
   "type": "index-branch",
   "category": "safety",
   "files": [
-    { "title": "Safety Guidelines", "file": "plans/safety/overview.md", "tags": ["safety"], "context_priority": "high" }
+    {
+      "title": "Safety Guidelines",
+      "file": "plans/safety/overview.md",
+      "tags": ["safety"],
+      "aliases": [],
+      "context_priority": "high"
+    }
   ]
 }

--- a/memory/plans/structure/index.json
+++ b/memory/plans/structure/index.json
@@ -2,6 +2,12 @@
   "type": "index-branch",
   "category": "structure",
   "files": [
-    { "title": "Structure Plan", "file": "plans/structure/layout.md", "tags": ["structure"], "context_priority": "high" }
+    {
+      "title": "Structure Plan",
+      "file": "plans/structure/layout.md",
+      "tags": ["structure"],
+      "aliases": [],
+      "context_priority": "high"
+    }
   ]
 }

--- a/tests/findMatchingFile.test.js
+++ b/tests/findMatchingFile.test.js
@@ -1,0 +1,49 @@
+process.env.NO_GIT = "true";
+const assert = require('assert');
+const { findMatchingFile } = require('../tools/index_utils');
+
+(function run() {
+  const index = {
+    files: [
+      {
+        title: 'Введение в переменные',
+        file: 'lesson_variables.md',
+        tags: ['переменные', 'начало', 'значения'],
+        aliases: ['variables', 'перем'],
+        priority: 'high'
+      },
+      {
+        title: 'Условные операторы',
+        file: 'lesson_if.md',
+        tags: ['условия'],
+        aliases: ['if'],
+        priority: 'medium'
+      }
+    ]
+  };
+
+  let matches = findMatchingFile(index, 'перем');
+  assert.strictEqual(matches.length, 1, 'alias partial match');
+  assert.strictEqual(matches[0].file, 'lesson_variables.md');
+
+  matches = findMatchingFile(index, 'variables');
+  assert.strictEqual(matches.length, 1, 'alias exact match');
+  assert.strictEqual(matches[0].file, 'lesson_variables.md');
+
+  matches = findMatchingFile(index, 'if');
+  assert.strictEqual(matches[0].file, 'lesson_if.md', 'search by alias');
+
+  matches = findMatchingFile(index, 'notfound');
+  assert.strictEqual(matches.length, 0, 'no results');
+
+  const index2 = {
+    files: [
+      { title: 'A', file: 'a.md', tags: ['tag'], aliases: [], priority: 'low' },
+      { title: 'B', file: 'b.md', tags: ['tag'], aliases: [], priority: 'high' }
+    ]
+  };
+  matches = findMatchingFile(index2, 'tag');
+  assert.strictEqual(matches[0].file, 'b.md', 'sorted by priority');
+
+  console.log('findMatchingFile tests passed');
+})();

--- a/tools/index_utils.js
+++ b/tools/index_utils.js
@@ -82,9 +82,25 @@ function hasMatchingTag(entry, queryTag) {
   return [...tags, ...aliases].includes(queryTag);
 }
 
+function findMatchingFile(indexObject, keyword) {
+  if (!indexObject || !keyword) return [];
+  const files = Array.isArray(indexObject.files) ? indexObject.files : [];
+  const query = String(keyword).toLowerCase();
+  const matches = files.filter(entry => {
+    const fields = [entry.title, entry.file];
+    if (Array.isArray(entry.tags)) fields.push(...entry.tags);
+    if (Array.isArray(entry.aliases)) fields.push(...entry.aliases);
+    return fields.some(v =>
+      v && String(v).toLowerCase().includes(query)
+    );
+  });
+  return sort_by_priority(matches);
+}
+
 module.exports = {
   index_to_array,
   array_to_index,
   sort_by_priority,
-  hasMatchingTag
+  hasMatchingTag,
+  findMatchingFile
 };


### PR DESCRIPTION
## Summary
- support `aliases` in memory indexes
- implement `findMatchingFile` utility for keyword search
- load lessons using new finder
- test alias and tag matching

## Testing
- `npm test` *(fails: cannot find module 'ajv' and git errors)*

------
https://chatgpt.com/codex/tasks/task_e_6860ff8ed1c08323897a6ccbd1ccb584