### PR TITLE
Add Markdown TOC generator

### DIFF
--- a/tests/markdown_utils.test.js
+++ b/tests/markdown_utils.test.js
@@ -1,7 +1,11 @@
 const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
-const { safeUpdateMarkdownChecklist } = require('../utils/markdown_utils');
+const {
+  safeUpdateMarkdownChecklist,
+  generateMarkdownTOC,
+  insertTOCInMarkdownFile,
+} = require('../utils/markdown_utils');
 
 const tmpDir = path.join(__dirname, 'tmp_md_utils');
 if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir);
@@ -30,4 +34,44 @@ if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir);
   assert.ok(text.includes('- [ ] two'), 'status reverted');
 
   console.log('markdown_utils safe update tests passed');
+})();
+
+(async function runTOC(){
+  const tocDir = path.join(tmpDir, 'toc');
+  if (!fs.existsSync(tocDir)) fs.mkdirSync(tocDir);
+
+  const mdPath = path.join(tocDir, 'lesson.md');
+  const content = [
+    '# Lesson',
+    '',
+    '## Что такое переменные',
+    'text',
+    '### Example',
+    'code',
+    '## End'
+  ].join('\n');
+  fs.writeFileSync(mdPath, content, 'utf-8');
+
+  // anchor insertion
+  const anchorPath = path.join(tocDir, 'anchor.md');
+  fs.writeFileSync(anchorPath, '# T\n\n<!-- TOC -->\n\n## A');
+
+  const tocString = generateMarkdownTOC(content);
+  assert.ok(tocString.includes('- [Что такое переменные](#что-такое-переменные)'));
+
+  await insertTOCInMarkdownFile(anchorPath);
+  let txt = fs.readFileSync(anchorPath, 'utf-8');
+  assert.ok(txt.includes('## Оглавление'), 'toc inserted at anchor');
+  assert.ok(!txt.includes('<!-- TOC -->'), 'anchor removed');
+
+  // insertion after heading and no duplicate
+  await insertTOCInMarkdownFile(mdPath, { useTOCAnchor: false });
+  txt = fs.readFileSync(mdPath, 'utf-8');
+  assert.strictEqual((txt.match(/## Оглавление/g) || []).length, 1);
+
+  await insertTOCInMarkdownFile(mdPath, { useTOCAnchor: false });
+  txt = fs.readFileSync(mdPath, 'utf-8');
+  assert.strictEqual((txt.match(/## Оглавление/g) || []).length, 1, 'no duplicate');
+
+  console.log('markdown_utils toc tests passed');
 })();


### PR DESCRIPTION
## Summary
- add generateMarkdownTOC and insertTOCInMarkdownFile utilities
- cover TOC generation and insertion with tests

## Testing
- `npm test` *(fails: index errors)*

------
https://chatgpt.com/codex/tasks/task_e_68610246f5d88323b155df74d2415ae6