### PR TITLE
Implement summary counters for index operations

### DIFF
--- a/logic/memory_operations.js
+++ b/logic/memory_operations.js
@@ -19,20 +19,13 @@ const {
 } = require('../tools/memory_helpers');
 const memory_settings = require('../tools/memory_settings');
 const { parseFrontMatter } = require('../utils/markdown_utils');
+const { appendSummaryLog } = require('../versioning');
 
 const contextFilename = path.join(__dirname, '..', 'memory', 'context.md');
 const planFilename = path.join(__dirname, '..', 'memory', 'plan.md');
 const indexFilename = path.join(__dirname, '..', 'memory', 'index.json');
 
-const logsDir = path.join(__dirname, '..', 'logs');
-const summaryFile = path.join(logsDir, 'summary.log');
-
 const opCounts = { added: 0, updated: 0, skipped: 0, preserved: 0 };
-
-function appendSummaryLog(line) {
-  fs.mkdirSync(logsDir, { recursive: true });
-  fs.appendFileSync(summaryFile, line + '\n');
-}
 
 let planCache = null;
 
@@ -713,9 +706,9 @@ async function persistIndex(data, repo, token, userId) {
     }
   }
 
-  const summary = { ...opCounts };
-  console.log('[Index Summary]', summary);
-  appendSummaryLog(`[Index Summary] ${JSON.stringify(summary)}`);
+  const summary = `[Index Summary] added: ${opCounts.added}, updated: ${opCounts.updated}, skipped: ${opCounts.skipped}, preserved: ${opCounts.preserved}`;
+  console.log(summary);
+  appendSummaryLog(summary);
   opCounts.added = 0;
   opCounts.updated = 0;
   opCounts.skipped = 0;

--- a/versioning.js
+++ b/versioning.js
@@ -10,6 +10,8 @@ function appendSummaryLog(line) {
   fs.appendFileSync(summaryFile, line + '\n');
 }
 
+exports.appendSummaryLog = appendSummaryLog;
+
 exports.commit_instructions = async (req, res) => {
   try {
     const { version = 'base', content } = req.body || {};


### PR DESCRIPTION
## Summary
- reuse `appendSummaryLog` from `versioning.js`
- log preserved operations when saving beyond context limit
- report added/updated/skipped/preserved counts after persisting index

## Testing
- `npm test` *(fails: index.findIndex is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68613ac9ecb48323a4a623b8bfd34c40