### PR TITLE
Implement restoreContext API helper

### DIFF
--- a/tests/restore_context_api.test.js
+++ b/tests/restore_context_api.test.js
@@ -1,0 +1,17 @@
+const assert = require('assert');
+const axios = require('axios');
+const { restoreContext } = require('../utils/restore_context');
+
+(async function run(){
+  const origPost = axios.post;
+  let called = false;
+  axios.post = async (url, data) => {
+    called = url.includes('/loadMemoryToContext') && data.userId === 'user123';
+    return { data: { success: true } };
+  };
+  const res = await restoreContext('user123');
+  axios.post = origPost;
+  assert.ok(called, 'endpoint should be called');
+  assert.deepStrictEqual(res, { success: true });
+  console.log('restoreContext api test passed');
+})();

--- a/utils/restore_context.js
+++ b/utils/restore_context.js
@@ -1,0 +1,19 @@
+const axios = require('axios');
+
+/**
+ * Request context restoration via API.
+ * @param {string|null} userId user identifier
+ * @returns {Promise<object>} API response
+ */
+async function restoreContext(userId) {
+  const endpoint = 'https://sofia-memory.onrender.com/loadMemoryToContext';
+  try {
+    const res = await axios.post(endpoint, { userId });
+    return res.data;
+  } catch (e) {
+    console.error('[restoreContext] request failed', e.message);
+    throw e;
+  }
+}
+
+module.exports = { restoreContext };


### PR DESCRIPTION
## Summary
- add helper to request context restore from API
- test restoreContext using mocked axios

## Testing
- `node tests/restore_context_api.test.js`
- `npm test` *(fails: index consistency and other tests)*

------
https://chatgpt.com/codex/tasks/task_e_6861636b98748323b958a89f1127655c