### PR TITLE
Add multi-user context support

### DIFF
--- a/tests/check_and_restore_context.test.js
+++ b/tests/check_and_restore_context.test.js
@@ -5,13 +5,13 @@ const context_state = require('../tools/context_state');
 
 async function run() {
   await setMemoryRepo(null, null);
-  context_state.reset_tokens();
+  context_state.reset_tokens('user1');
 
-  await checkAndRestoreContext('theory', 50);
+  await checkAndRestoreContext('theory', 50, 'user1');
 
-  const res = await checkAndRestoreContext('practice', 2100);
+  const res = await checkAndRestoreContext('practice', 2100, 'user1');
   assert.ok(res.restored, 'context should be restored when token limit exceeded');
-  assert.strictEqual(context_state.get_tokens(), 0);
+  assert.strictEqual(context_state.get_tokens('user1'), 0);
 
   console.log('checkAndRestoreContext tests passed');
 }

--- a/tests/context_multi_user.test.js
+++ b/tests/context_multi_user.test.js
@@ -1,0 +1,17 @@
+process.env.NO_GIT = "true";
+const assert = require('assert');
+const context_state = require('../tools/context_state');
+
+async function run() {
+  context_state.reset_tokens('u1');
+  context_state.reset_tokens('u2');
+  context_state.increment_tokens(10, 'u1');
+  context_state.increment_tokens(20, 'u2');
+  assert.strictEqual(context_state.get_tokens('u1'), 10);
+  assert.strictEqual(context_state.get_tokens('u2'), 20);
+  context_state.reset_tokens('u1');
+  assert.strictEqual(context_state.get_tokens('u1'), 0);
+  assert.strictEqual(context_state.get_tokens('u2'), 20);
+  console.log('context multi-user tests passed');
+}
+run();

--- a/tests/token_counter.test.js
+++ b/tests/token_counter.test.js
@@ -5,19 +5,19 @@ const context_state = require('../tools/context_state');
 
 async function run() {
   await setMemoryRepo(null, null);
-  context_state.reset_tokens();
-  context_state.set_needs_refresh(false);
+  context_state.reset_tokens('user1');
+  context_state.set_needs_refresh(false, 'user1');
 
-  context_state.increment_tokens(150);
-  let info = getTokenCounter();
+  context_state.increment_tokens(150, 'user1');
+  let info = getTokenCounter('user1');
   assert.strictEqual(info.used, 150);
-  assert.ok(formatTokenCounter(true).includes('150/'));
+  assert.ok(formatTokenCounter(true, 'user1').includes('150/'));
 
-  const res = await checkAndRestoreContext('practice', 1950);
+  const res = await checkAndRestoreContext('practice', 1950, 'user1');
   assert.ok(res.restored, 'context should refresh after limit');
-  info = getTokenCounter();
+  info = getTokenCounter('user1');
   assert.strictEqual(info.used, 0);
-  assert.ok(formatTokenCounter(true).includes('0/'));
+  assert.ok(formatTokenCounter(true, 'user1').includes('0/'));
 
   console.log('token counter tests passed');
 }


### PR DESCRIPTION
## Summary
- manage context state per user
- propagate userId through context checks and token counters
- update tests for multi-user context

## Testing
- `npm test` *(fails: index schema invalid, git pull errors)*

------
https://chatgpt.com/codex/tasks/task_e_686165f8cb5883239ef830277eb4e874