### PR TITLE
Add context restore logging and tests

### DIFF
--- a/tests/restore_context_api.test.js
+++ b/tests/restore_context_api.test.js
@@ -5,13 +5,21 @@ const { restoreContext } = require('../utils/restore_context');
 (async function run(){
   const origPost = axios.post;
   let called = false;
+  const logs = [];
+  const origLog = console.log;
+  const origErr = console.error;
+  console.log = (...a) => logs.push(a.join(' '));
+  console.error = (...a) => logs.push(a.join(' '));
   axios.post = async (url, data) => {
     called = url.includes('/loadMemoryToContext') && data.userId === 'user123';
     return { data: { success: true } };
   };
   const res = await restoreContext('user123');
   axios.post = origPost;
+  console.log = origLog;
+  console.error = origErr;
   assert.ok(called, 'endpoint should be called');
   assert.deepStrictEqual(res, { success: true });
+  assert.ok(logs.find(l => l.includes('\u043a\u043e\u043d\u0442\u0435\u043a\u0441\u0442 \u0432\u043e\u0441\u0441\u0442\u0430\u043d\u043e\u0432\u043b\u0435\u043d')));
   console.log('restoreContext api test passed');
 })();

--- a/tests/restore_context_api_fail.test.js
+++ b/tests/restore_context_api_fail.test.js
@@ -1,0 +1,25 @@
+const assert = require('assert');
+const axios = require('axios');
+const { restoreContext } = require('../utils/restore_context');
+
+(async function run(){
+  const origPost = axios.post;
+  const logs = [];
+  const origLog = console.log;
+  const origErr = console.error;
+  console.log = (...a) => logs.push(a.join(' '));
+  console.error = (...a) => logs.push(a.join(' '));
+  axios.post = async () => { throw new Error('fail'); };
+  let threw = false;
+  try {
+    await restoreContext('bad');
+  } catch {
+    threw = true;
+  }
+  axios.post = origPost;
+  console.log = origLog;
+  console.error = origErr;
+  assert.ok(threw, 'should throw on failure');
+  assert.ok(logs.find(l => l.includes('\u043e\u0448\u0438\u0431\u043a\u0430 \u0432\u043e\u0441\u0441\u0442\u0430')));
+  console.log('restoreContext failure test passed');
+})();

--- a/utils/restore_context.js
+++ b/utils/restore_context.js
@@ -1,4 +1,16 @@
 const axios = require('axios');
+const logger = require('./logger');
+
+function logRestoreAction(userId, success) {
+  const msg = success
+    ? `\u041a\u043e\u043d\u0442\u0435\u043a\u0441\u0442 \u0432\u043e\u0441\u0441\u0442\u0430\u043d\u043e\u0432\u043b\u0435\u043d \u0434\u043b\u044f \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f: ${userId}`
+    : `\u041e\u0448\u0438\u0431\u043a\u0430 \u0432\u043e\u0441\u0441\u0442\u0430\u043d\u043e\u0432\u043b\u0435\u043d\u0438\u044f \u043a\u043e\u043d\u0442\u0435\u043a\u0441\u0442\u0430 \u0434\u043b\u044f \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f: ${userId}`;
+  if (success) {
+    logger.info(msg);
+  } else {
+    logger.error(msg);
+  }
+}
 
 /**
  * Request context restoration via API.
@@ -9,11 +21,13 @@ async function restoreContext(userId) {
   const endpoint = 'https://sofia-memory.onrender.com/loadMemoryToContext';
   try {
     const res = await axios.post(endpoint, { userId });
+    logRestoreAction(userId, true);
     return res.data;
   } catch (e) {
-    console.error('[restoreContext] request failed', e.message);
+    logRestoreAction(userId, false);
+    logger.error('[restoreContext] request failed', e.message);
     throw e;
   }
 }
 
-module.exports = { restoreContext };
+module.exports = { restoreContext, logRestoreAction };


### PR DESCRIPTION
## Summary
- log restore context actions in `utils/restore_context`
- add logging in context restoration helpers
- test successful and failed context restoration

## Testing
- `npm test` *(fails: index issues and git pull errors)*

------
https://chatgpt.com/codex/tasks/task_e_68616c3880b48323aaa9c223511fe001