### PR TITLE
Implement periodic context check

### DIFF
--- a/tests/periodic_context_check.test.js
+++ b/tests/periodic_context_check.test.js
@@ -1,0 +1,18 @@
+process.env.NO_GIT = "true";
+const fs = require('fs');
+const assert = require('assert');
+const router = require('../api/memory_routes');
+const restore_utils = require('../utils/restore_context');
+const { contextFilename } = require('../logic/memory_operations');
+
+(async function run(){
+  fs.writeFileSync(contextFilename, '');
+  const origRestore = restore_utils.restoreContext;
+  let called = false;
+  restore_utils.restoreContext = async (id) => { called = id === 'testUser'; };
+  await router._check_context_for_user('testUser');
+  restore_utils.restoreContext = origRestore;
+  fs.writeFileSync(contextFilename, '');
+  assert.ok(called, 'restoreContext should be called when context missing');
+  console.log('periodic context check test passed');
+})();


### PR DESCRIPTION
## Summary
- periodically check user contexts from `memory_routes`
- add batch processing and logging for context restoration
- provide internal functions for testing
- test periodic context check logic

## Testing
- `npm test` *(fails: index_consistency.test.js among others)*

------
https://chatgpt.com/codex/tasks/task_e_68617485955c83239184e221b36e6da6