### PR TITLE
Implement Markdown file split with structural processing

### DIFF
--- a/tests/markdown_file_splitter.test.js
+++ b/tests/markdown_file_splitter.test.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const { splitMarkdownFile, MAX_MD_FILE_SIZE } = require('../utils/file_splitter');
+
+const tmpDir = path.join(__dirname, 'tmp_md_file_split');
+if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir, { recursive: true });
+
+(function run(){
+  const src = path.join(tmpDir, 'big.md');
+  const line = '# Heading\n\nSome text here\n';
+  const repeat = Math.ceil((MAX_MD_FILE_SIZE + 1024) / Buffer.byteLength(line));
+  fs.writeFileSync(src, line.repeat(repeat), 'utf-8');
+
+  const parts = splitMarkdownFile(src);
+  assert.ok(parts.length > 1, 'file should be split');
+  parts.forEach(p => {
+    assert.ok(fs.existsSync(p), `part ${p} exists`);
+    const sz = fs.statSync(p).size;
+    assert.ok(sz <= MAX_MD_FILE_SIZE, 'part within size limit');
+  });
+
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  console.log('markdown file splitter tests passed');
+})();

--- a/utils/file_splitter.js
+++ b/utils/file_splitter.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { parseMarkdownStructure, serializeMarkdownTree } = require('../logic/markdown_merge_engine.ts');
 
 // Константы для максимального размера файлов
 const MAX_MD_FILE_SIZE = 500 * 1024;  // 500 KB для Markdown файлов
@@ -35,4 +36,22 @@ function splitFile(filePath, maxSize) {
   return parts;
 }
 
-module.exports = { MAX_MD_FILE_SIZE, MAX_INDEX_FILE_SIZE, splitFile };
+/**
+ * Split a markdown file into parts respecting MAX_MD_FILE_SIZE.
+ * Each part is parsed and serialized to preserve structure.
+ * @param {string} filePath
+ * @param {number} [maxSize=MAX_MD_FILE_SIZE]
+ * @returns {string[]} array of part file paths
+ */
+function splitMarkdownFile(filePath, maxSize = MAX_MD_FILE_SIZE) {
+  const partPaths = splitFile(filePath, maxSize);
+  partPaths.forEach(p => {
+    const raw = fs.readFileSync(p, 'utf-8');
+    const tree = parseMarkdownStructure(raw);
+    const out = serializeMarkdownTree(tree);
+    fs.writeFileSync(p, out, 'utf-8');
+  });
+  return partPaths;
+}
+
+module.exports = { MAX_MD_FILE_SIZE, MAX_INDEX_FILE_SIZE, splitFile, splitMarkdownFile };


### PR DESCRIPTION
## Summary
- add `splitMarkdownFile` to split large Markdown files using `splitFile`
- ensure each Markdown part is parsed and serialized for structure
- include tests for markdown file splitting

## Testing
- `npm test` *(fails: index.findIndex is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_686181291e5c83239b704e08a525c5bc