### PR TITLE
Implement index file splitting utilities

### DIFF
--- a/tests/index_file_splitter.test.js
+++ b/tests/index_file_splitter.test.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const { splitIndexFile } = require('../utils/file_splitter');
+
+const tmpDir = path.join(__dirname, 'tmp_index_split');
+if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir, { recursive: true });
+
+(function run(){
+  const idx = path.join(tmpDir, 'index.json');
+  const data = { type: 'index-branch', category: 'tmp', files: [] };
+  for(let i=0;i<50;i++) data.files.push({ file: `f${i}.md`, title: `T${i}` });
+  fs.writeFileSync(idx, JSON.stringify(data, null, 2), 'utf8');
+
+  const parts = splitIndexFile(idx, 1000);
+  assert.ok(parts.length > 1, 'index should be split');
+  parts.forEach(p => {
+    assert.ok(fs.existsSync(p), `part ${p} exists`);
+    const parsed = JSON.parse(fs.readFileSync(p, 'utf8'));
+    assert.ok(Array.isArray(parsed.files));
+  });
+
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  console.log('index file splitter tests passed');
+})();

--- a/utils/file_splitter.js
+++ b/utils/file_splitter.js
@@ -54,4 +54,80 @@ function splitMarkdownFile(filePath, maxSize = MAX_MD_FILE_SIZE) {
   return partPaths;
 }
 
-module.exports = { MAX_MD_FILE_SIZE, MAX_INDEX_FILE_SIZE, splitFile, splitMarkdownFile };
+/**
+ * Split index data into chunks respecting size limit.
+ * @param {object} indexData
+ * @param {number} [maxSize=MAX_INDEX_FILE_SIZE]
+ * @returns {object[]}
+ */
+function splitIndexData(indexData, maxSize = MAX_INDEX_FILE_SIZE) {
+  if (!Array.isArray(indexData.files)) return [indexData];
+
+  const parts = [];
+  let current = [];
+
+  const flush = () => {
+    if (!current.length) return;
+    parts.push({ ...indexData, files: current });
+    current = [];
+  };
+
+  indexData.files.forEach(entry => {
+    current.push(entry);
+    const tmp = JSON.stringify({ ...indexData, files: current });
+    if (Buffer.byteLength(tmp, 'utf-8') > maxSize && current.length > 1) {
+      current.pop();
+      flush();
+      current.push(entry);
+    }
+  });
+  flush();
+  return parts;
+}
+
+/**
+ * Split an index file into multiple files if needed.
+ * Each part is written next to the original with .partN suffix.
+ * @param {string} indexPath
+ * @param {number} [maxSize=MAX_INDEX_FILE_SIZE]
+ * @returns {string[]} paths to part files
+ */
+function splitIndexFile(indexPath, maxSize = MAX_INDEX_FILE_SIZE) {
+  const stats = fs.statSync(indexPath);
+  if (stats.size <= maxSize) return [indexPath];
+
+  const raw = fs.readFileSync(indexPath, 'utf-8');
+  const data = JSON.parse(raw);
+  const dir = path.dirname(indexPath);
+  const base = path.basename(indexPath, '.json');
+
+  const partsData = splitIndexData(data, maxSize);
+  const outPaths = [];
+  partsData.forEach((part, idx) => {
+    const p = idx === 0 ? indexPath : path.join(dir, `${base}.part${idx + 1}.json`);
+    fs.writeFileSync(p, JSON.stringify(part, null, 2), 'utf-8');
+    outPaths.push(p);
+  });
+
+  let n = partsData.length + 1;
+  while (true) {
+    const extra = path.join(dir, `${base}.part${n}.json`);
+    if (fs.existsSync(extra)) {
+      fs.unlinkSync(extra);
+      n++;
+    } else {
+      break;
+    }
+  }
+
+  return outPaths;
+}
+
+module.exports = {
+  MAX_MD_FILE_SIZE,
+  MAX_INDEX_FILE_SIZE,
+  splitFile,
+  splitMarkdownFile,
+  splitIndexData,
+  splitIndexFile,
+};


### PR DESCRIPTION
## Summary
- extend `file_splitter` with utilities to divide JSON indexes
- add tests for splitting index files

## Testing
- `npm test` *(fails: Command failed due to git operations)*

------
https://chatgpt.com/codex/tasks/task_e_68618876f6b48323bf8e081406d26f0d