### PR TITLE
Fix findIndex usage

### DIFF
--- a/logic/memory_operations.js
+++ b/logic/memory_operations.js
@@ -33,7 +33,9 @@ async function safeUpdateIndexEntry(newEntry) {
   let index = [];
   try {
     const raw = fs.readFileSync(indexFilename, 'utf-8');
-    index = JSON.parse(raw);
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) index = parsed;
+    else return; // unsupported format
   } catch (e) {
     console.warn('[INDEX] index.json not found or corrupted, creating new');
   }


### PR DESCRIPTION
## Summary
- guard safeUpdateIndexEntry against non-array index formats

## Testing
- `npm test` *(fails: move_file_update_index.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68619e02aec083238503eb9b9bbf754b