### PR TITLE
Update index size defaults

### DIFF
--- a/logic/index_validator.js
+++ b/logic/index_validator.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { MAX_INDEX_FILE_SIZE } = require('../utils/file_splitter');
 
 const indexSettings = {
   validate_on_load: true,
@@ -7,7 +8,7 @@ const indexSettings = {
   auto_clean_missing: false,
   require_manual_meta: true,
   block_plugin_paths: true,
-  max_index_size: 100 * 1024,
+  max_index_size: MAX_INDEX_FILE_SIZE,
 };
 
 function normalize(p) {

--- a/tools/index_splitter.js
+++ b/tools/index_splitter.js
@@ -1,8 +1,9 @@
 const fs = require('fs');
 const fsp = fs.promises;
 const path = require('path');
+const { MAX_INDEX_FILE_SIZE } = require('../utils/file_splitter');
 
-async function checkAndSplitIndex(indexPath, maxSize = 100 * 1024) {
+async function checkAndSplitIndex(indexPath, maxSize = MAX_INDEX_FILE_SIZE) {
   try {
     const stats = await fsp.stat(indexPath);
     if (stats.size <= maxSize) return;
@@ -12,7 +13,7 @@ async function checkAndSplitIndex(indexPath, maxSize = 100 * 1024) {
   }
 }
 
-async function splitIndexFile(indexPath, maxSize = 100 * 1024) {
+async function splitIndexFile(indexPath, maxSize = MAX_INDEX_FILE_SIZE) {
   try {
     await fsp.access(indexPath);
   } catch {


### PR DESCRIPTION
## Summary
- import MAX_INDEX_FILE_SIZE and use it inside index validator
- default index splitting helpers to MAX_INDEX_FILE_SIZE

## Testing
- `npm test` *(fails: assertion errors during tests)*

------
https://chatgpt.com/codex/tasks/task_e_6861ce4027f48323bf9d99bc005b265f