### PR TITLE
Implement simple access control

### DIFF
--- a/utils/access_control.js
+++ b/utils/access_control.js
@@ -1,0 +1,21 @@
+const path = require('path');
+
+function normalize(p){
+  return p.replace(/\\+/g, '/').replace(/^\/+/, '').replace(/^\.\/+/, '');
+}
+
+function checkAccess(filePath, mode = 'read') {
+  const rel = normalize(filePath);
+  if (rel.startsWith('memory/')) {
+    return { allowed: true };
+  }
+  if (rel.startsWith('code/') || rel.startsWith('src/') || rel.startsWith('logic/')) {
+    if (mode === 'write') {
+      return { allowed: false, message: 'Доступ к изменениям кода проекта запрещен' };
+    }
+    return { allowed: true };
+  }
+  return { allowed: mode === 'read', message: mode === 'write' ? 'Доступ к изменениям кода проекта запрещен' : 'Недостаточно прав' };
+}
+
+module.exports = { checkAccess };


### PR DESCRIPTION
## Summary
- implement `checkAccess` utility to enforce path permissions
- restrict remote and local writes using `checkAccess`

## Testing
- `npm test` *(fails: ENOENT errors in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6861eb4d5b3483238ea5c5590afae27d