### PR TITLE
Add repository index support

### DIFF
--- a/api/github_routes.js
+++ b/api/github_routes.js
@@ -1,6 +1,13 @@
 const express = require('express');
 const router = express.Router();
-const { listUserRepos, getRepoContents, fetchFileContent, saveRepositoryData } = require('../logic/github_repo');
+const {
+  listUserRepos,
+  getRepoContents,
+  fetchFileContent,
+  saveRepositoryData,
+  createOrUpdateRepoIndex,
+  markFileChecked,
+} = require('../logic/github_repo');
 const { lintText } = require('../utils/code_analyzer');
 
 router.post('/github/repos', async (req, res) => {
@@ -20,6 +27,7 @@ router.post('/github/repository', async (req, res) => {
   try {
     const data = await getRepoContents(token, owner, repo, path, page);
     await saveRepositoryData(owner, repo, data);
+    await createOrUpdateRepoIndex(token, owner, repo);
     res.json({ status: 'success', contents: data });
   } catch (e) {
     res.status(500).json({ status: 'error', message: e.message });
@@ -32,6 +40,7 @@ router.post('/github/file', async (req, res) => {
   try {
     const content = await fetchFileContent(token, owner, repo, filePath);
     const lint = await lintText(content);
+    await markFileChecked(owner, repo, filePath);
     res.json({ status: 'success', content, lint });
   } catch (e) {
     res.status(500).json({ status: 'error', message: e.message });

--- a/tests/repo_index.test.js
+++ b/tests/repo_index.test.js
@@ -1,0 +1,34 @@
+process.env.NO_GIT = "true";
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const axios = require('axios');
+const { createOrUpdateRepoIndex, markFileChecked } = require('../logic/github_repo');
+
+(async function run(){
+  const origGet = axios.get;
+  axios.get = async () => ({ data: { tree: [
+    { path: 'README.md', type: 'blob' },
+    { path: 'src', type: 'tree' },
+    { path: 'src/index.js', type: 'blob' }
+  ] } });
+
+  const dir = path.join(__dirname, '..', 'memory', 'github');
+  fs.rmSync(dir, { recursive: true, force: true });
+
+  await createOrUpdateRepoIndex('tok','owner','repo');
+  const indexPath = path.join(dir, 'owner-repo-index.json');
+  assert.ok(fs.existsSync(indexPath), 'index file created');
+  let data = JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
+  const entry = data.find(e => e.path === 'src/index.js');
+  assert.ok(entry && !entry.checked, 'entry exists');
+
+  await markFileChecked('owner','repo','src/index.js');
+  data = JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
+  const checked = data.find(e => e.path === 'src/index.js');
+  assert.ok(checked.checked, 'file marked as checked');
+
+  axios.get = origGet;
+  fs.rmSync(dir, { recursive: true, force: true });
+  console.log('repo index tests passed');
+})();


### PR DESCRIPTION
## Summary
- index GitHub repository contents when accessed
- mark repository files as checked after analysis
- store repository index in `memory/github`
- test repository indexing logic

## Testing
- `npm test` *(fails: AssertionError in move_file_update_index.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6861ef9627688323aa1dfe84e6dce8eb