### PR TITLE
Implement memory file filtering

### DIFF
--- a/tests/memory_filter.test.js
+++ b/tests/memory_filter.test.js
@@ -1,0 +1,27 @@
+process.env.NO_GIT = "true";
+const assert = require('assert');
+const { filterMemoryFiles } = require('../tools/index_utils');
+
+(function run() {
+  const files = [
+    { category: 'lessons', tags: ['intro'], path: 'memory/lessons/intro.md' },
+    { category: 'notes', tags: ['js'], path: 'memory/notes/js.md' },
+    { category: 'lessons', tags: ['advanced'], path: 'memory/lessons/adv.md' }
+  ];
+
+  let result = filterMemoryFiles(files, { category: 'lessons' });
+  assert.strictEqual(result.length, 2, 'filter by category');
+
+  result = filterMemoryFiles(files, { topic: 'js' });
+  assert.strictEqual(result.length, 1, 'filter by tag');
+  assert.strictEqual(result[0].path, 'memory/notes/js.md');
+
+  result = filterMemoryFiles(files, { category: 'plans', topic: 'intro' });
+  assert.strictEqual(result.length, 1, 'category or tag');
+  assert.strictEqual(result[0].path, 'memory/lessons/intro.md');
+
+  result = filterMemoryFiles(files, { category: 'plans', topic: 'none' });
+  assert.strictEqual(result.length, 0, 'no matches');
+
+  console.log('memory filter tests passed');
+})();

--- a/tools/index_utils.js
+++ b/tools/index_utils.js
@@ -97,10 +97,24 @@ function findMatchingFile(indexObject, keyword) {
   return sort_by_priority(matches);
 }
 
+function filterMemoryFiles(memoryFiles = [], context = {}) {
+  const { category, topic } = context;
+  return memoryFiles.filter(file => {
+    const tags = Array.isArray(file.tags) ? file.tags : [];
+    const catMatch = category && file.category === category;
+    const tagMatch = topic && tags.includes(topic);
+    if (category && topic) return catMatch || tagMatch;
+    if (category) return catMatch;
+    if (topic) return tagMatch;
+    return true;
+  });
+}
+
 module.exports = {
   index_to_array,
   array_to_index,
   sort_by_priority,
   hasMatchingTag,
-  findMatchingFile
+  findMatchingFile,
+  filterMemoryFiles
 };


### PR DESCRIPTION
## Summary
- add `filterMemoryFiles` to index utils
- create `memory_filter.test.js` to cover filtering behaviour

## Testing
- `node tests/memory_filter.test.js`
- `npm test` *(fails: move_file_update_index.test.js assertion error)*

------
https://chatgpt.com/codex/tasks/task_e_6861f4e04b988323b6a5eef0d45c230d