### PR TITLE
Implement LRU cache for GitHub API results

### DIFF
--- a/tests/github_repo_cache.test.js
+++ b/tests/github_repo_cache.test.js
@@ -1,0 +1,23 @@
+process.env.NO_GIT = "true";
+const assert = require('assert');
+const axios = require('axios');
+const { listUserRepos, clearCache } = require('../logic/github_repo');
+
+(async function run(){
+  clearCache();
+  const origGet = axios.get;
+  let count = 0;
+  axios.get = async () => { count++; return { data: ['r'] }; };
+
+  await listUserRepos('tok');
+  await listUserRepos('tok');
+  assert.strictEqual(count, 1, 'result cached');
+
+  clearCache();
+  await listUserRepos('tok');
+  assert.strictEqual(count, 2, 'cache cleared');
+
+  axios.get = origGet;
+  clearCache();
+  console.log('github repo cache test passed');
+})();

--- a/tests/lru_cache.test.js
+++ b/tests/lru_cache.test.js
@@ -1,0 +1,14 @@
+const assert = require('assert');
+const LRUCache = require('../utils/lru_cache');
+
+(async function run(){
+  const cache = new LRUCache(2, 10);
+  cache.set('a', 1);
+  cache.set('b', 2);
+  assert.strictEqual(cache.get('a'), 1, 'retrieve existing');
+  cache.set('c', 3);
+  assert.strictEqual(cache.get('b'), undefined, 'oldest evicted');
+  await new Promise(r => setTimeout(r, 15));
+  assert.strictEqual(cache.get('a'), undefined, 'expired entry removed');
+  console.log('lru cache test passed');
+})();

--- a/utils/lru_cache.js
+++ b/utils/lru_cache.js
@@ -1,0 +1,43 @@
+class LRUCache {
+  constructor(limit = 100, ttl = 5 * 60 * 1000) {
+    this.limit = limit;
+    this.ttl = ttl;
+    this.map = new Map();
+  }
+
+  _isExpired(entry) {
+    return this.ttl > 0 && (Date.now() - entry.ts) > this.ttl;
+  }
+
+  get(key) {
+    const entry = this.map.get(key);
+    if (!entry) return undefined;
+    if (this._isExpired(entry)) {
+      this.map.delete(key);
+      return undefined;
+    }
+    // refresh order
+    this.map.delete(key);
+    this.map.set(key, entry);
+    return entry.value;
+  }
+
+  set(key, value) {
+    if (this.map.has(key)) this.map.delete(key);
+    this.map.set(key, { value, ts: Date.now() });
+    if (this.map.size > this.limit) {
+      const oldest = this.map.keys().next().value;
+      this.map.delete(oldest);
+    }
+  }
+
+  delete(key) {
+    this.map.delete(key);
+  }
+
+  clear() {
+    this.map.clear();
+  }
+}
+
+module.exports = LRUCache;


### PR DESCRIPTION
## Summary
- add generic LRU cache utility
- use the cache in `github_repo` for repository operations
- expose cache clearing helper
- test caching logic

## Testing
- `npm test` *(fails: move_file_update_index.test.js due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_68621dfbe0fc8323832ee73ac090e098