### PR TITLE
Implement dynamic index updates

### DIFF
--- a/src/storage.js
+++ b/src/storage.js
@@ -51,6 +51,16 @@ async function read_memory(user_id, repo, token, filename, opts = {}) {
     }
   }
 
+  if (!index_manager.validatePath(normalized)) {
+    await index_manager.addOrUpdateEntry({
+      path: normalized,
+      title: index_manager.generateTitleFromPath(normalized),
+      type: index_manager.inferTypeFromPath(normalized),
+      lastModified: new Date().toISOString(),
+    });
+    await index_manager.saveIndex(token, repo, user_id);
+  }
+
   if (parse_json && normalized.endsWith('.json')) {
     try {
       return JSON.parse(content);

--- a/tests/memory_dynamic_index_update.test.js
+++ b/tests/memory_dynamic_index_update.test.js
@@ -1,0 +1,27 @@
+process.env.NO_GIT = "true";
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const storage = require('../src/storage');
+const index_manager = require('../logic/index_manager');
+
+(async function run(){
+  const fileRel = 'memory/lessons/tmp_dynamic.md';
+  const abs = path.join(__dirname,'..',fileRel);
+  fs.mkdirSync(path.dirname(abs),{recursive:true});
+  fs.writeFileSync(abs,'hello');
+
+  await index_manager.loadIndex();
+  let found = index_manager.getByPath(fileRel);
+  assert.ok(!found);
+
+  const content = await storage.read_memory(null,null,null,fileRel);
+  assert.strictEqual(content,'hello');
+
+  await index_manager.loadIndex();
+  found = index_manager.getByPath(fileRel);
+  assert.ok(found && found.path===fileRel);
+
+  fs.rmSync(path.dirname(abs),{recursive:true,force:true});
+  console.log('memory dynamic index update tests passed');
+})();

--- a/tests/repo_dynamic_update.test.js
+++ b/tests/repo_dynamic_update.test.js
@@ -1,0 +1,28 @@
+process.env.NO_GIT = "true";
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const axios = require('axios');
+const { createOrUpdateRepoIndex, updateRepoIndexEntry } = require('../logic/github_repo');
+
+(async function run(){
+  const origGet = axios.get;
+  axios.get = async () => ({ data: { tree: [ { path: 'README.md', type: 'blob' } ] } });
+
+  const dir = path.join(__dirname,'..','memory','github');
+  fs.rmSync(dir,{recursive:true,force:true});
+
+  await createOrUpdateRepoIndex('tok','owner','repo');
+  const indexPath = path.join(dir,'owner-repo-index.json');
+  let data = JSON.parse(fs.readFileSync(indexPath,'utf-8'));
+  assert.strictEqual(data.length,1);
+
+  await updateRepoIndexEntry('owner','repo','src/new.js',{ analyzed:true });
+  data = JSON.parse(fs.readFileSync(indexPath,'utf-8'));
+  const added = data.find(e => e.path==='src/new.js');
+  assert.ok(added && added.analyzed);
+
+  axios.get = origGet;
+  fs.rmSync(dir,{recursive:true,force:true});
+  console.log('repo dynamic index update tests passed');
+})();


### PR DESCRIPTION
## Summary
- update GitHub repository index entries when files are analysed
- auto-add memory files to the index on read
- add regression tests for both project and memory index updates

## Testing
- `npm test` *(fails: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_68626e7ff37883238bedcd1cca2cdc83