### PR TITLE
Fix relParts iterable check in saveMemoryWithIndex

### DIFF
--- a/src/storage.js
+++ b/src/storage.js
@@ -175,7 +175,12 @@ async function save_memory_with_index(user_id, repo, token, filename, content) {
     return { split: true, parts: relParts };
   }
   const savedPath = await save_memory(user_id, repo, token, finalPath, content);
-  if (savedPath && savedPath.split) {
+  if (
+    savedPath &&
+    typeof savedPath === 'object' &&
+    savedPath.split &&
+    Array.isArray(savedPath.parts)
+  ) {
     const relParts = savedPath.parts;
     for (const p of relParts) {
       await index_manager.addOrUpdateEntry({

--- a/tests/saveMemoryWithIndex_no_split.test.js
+++ b/tests/saveMemoryWithIndex_no_split.test.js
@@ -1,0 +1,27 @@
+process.env.NO_GIT = "true";
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const index_manager = require('../logic/index_manager');
+
+(async function run() {
+  const rootIdx = path.join(__dirname, '..', 'memory', 'index.json');
+  const origRoot = fs.readFileSync(rootIdx, 'utf-8');
+
+  const rel = 'memory/tmp_save/test_save.md';
+  const abs = path.join(__dirname, '..', rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+
+  const content = 'Hello world';
+  const result = await index_manager.saveMemoryWithIndex(null, null, null, rel, content);
+  assert.strictEqual(typeof result, 'string', 'should return path string');
+
+  const saved = fs.readFileSync(abs, 'utf-8');
+  assert.strictEqual(saved, content);
+
+  fs.rmSync(path.dirname(abs), { recursive: true, force: true });
+  fs.writeFileSync(rootIdx, origRoot, 'utf-8');
+  await index_manager.loadIndex();
+
+  console.log('saveMemoryWithIndex no split test passed');
+})();


### PR DESCRIPTION
## Summary
- guard against string return value in `save_memory_with_index`
- add regression test for unsplit `saveMemoryWithIndex`

## Testing
- `node tests/saveMemoryWithIndex_no_split.test.js`

------
https://chatgpt.com/codex/tasks/task_e_686377312654832399910177f384b07f