### PR TITLE
Fix save_memory filename validation

### DIFF
--- a/src/storage.js
+++ b/src/storage.js
@@ -74,6 +74,12 @@ async function read_memory(user_id, repo, token, filename, opts = {}) {
 
 async function save_memory(user_id, repo, token, filename, content) {
   const normalized = normalize_memory_path(filename);
+  const parsed = path.posix.parse(normalized);
+  if (!parsed.ext) {
+    throw new Error(
+      `save_memory expects a file path, got directory: ${filename}`
+    );
+  }
   const finalRepo = repo || (await memory_config.getRepoUrl(user_id));
   const finalToken = token || (await token_store.getToken(user_id));
   const masked = finalToken ? `${finalToken.slice(0, 4)}...` : 'null';

--- a/tests/saveMemoryWithIndex_dir_error.test.js
+++ b/tests/saveMemoryWithIndex_dir_error.test.js
@@ -1,0 +1,18 @@
+process.env.NO_GIT = "true";
+const assert = require('assert');
+const index_manager = require('../logic/index_manager');
+
+(async function run(){
+  let err = null;
+  try {
+    await index_manager.saveMemoryWithIndex(null, null, null, 'memory/', 'hi');
+  } catch(e) {
+    err = e;
+  }
+  assert.ok(err, 'expected error for directory path');
+  assert.strictEqual(
+    err.message,
+    'save_memory expects a file path, got directory: memory/'
+  );
+  console.log('saveMemoryWithIndex directory path test passed');
+})();


### PR DESCRIPTION
## Summary
- validate `filename` in `save_memory` to ensure it's a file, not a directory
- test error handling for directory paths in `saveMemoryWithIndex`

## Testing
- `node tests/saveMemoryWithIndex_dir_error.test.js`
- `npm test` *(fails: index_consistency.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68637c142dbc8323b46cbad729388988