### PR TITLE
Enable per-user memory mode switching

### DIFF
--- a/api/openapi_lite.yaml
+++ b/api/openapi_lite.yaml
@@ -49,6 +49,27 @@ paths:
       responses:
         '200':
           description: Repo stored
+  /memory/set-mode:
+    post:
+      summary: Set memory mode for a user
+      operationId: setMemoryMode
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                userId:
+                  type: string
+                mode:
+                  type: string
+                  enum: [local, github]
+      responses:
+        '200':
+          description: Mode stored
+        '400':
+          description: Invalid mode
   /saveLessonPlan:
     post:
       summary: Update learning plan

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -49,6 +49,27 @@ paths:
       responses:
         '200':
           description: Repo stored
+  /memory/set-mode:
+    post:
+      summary: Set memory mode for a user
+      operationId: setMemoryMode
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                userId:
+                  type: string
+                mode:
+                  type: string
+                  enum: [local, github]
+      responses:
+        '200':
+          description: Mode stored
+        '400':
+          description: Invalid mode
   /saveLessonPlan:
     post:
       summary: Update learning plan

--- a/openapi_template.yaml
+++ b/openapi_template.yaml
@@ -49,6 +49,27 @@ paths:
       responses:
         '200':
           description: Repo stored
+  /memory/set-mode:
+    post:
+      summary: Set memory mode for a user
+      operationId: setMemoryMode
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                userId:
+                  type: string
+                mode:
+                  type: string
+                  enum: [local, github]
+      responses:
+        '200':
+          description: Mode stored
+        '400':
+          description: Invalid mode
   /saveLessonPlan:
     post:
       summary: Update learning plan

--- a/tests/autocontext_index.test.js
+++ b/tests/autocontext_index.test.js
@@ -40,9 +40,9 @@ async function run() {
 
   const manual = await load_context_from_index(idx_rel);
   assert.ok(manual && manual.files.includes(file2_rel));
-  assert.ok(fs.readFileSync(contextFilename, 'utf-8').includes('Vector'));
+  assert.ok(fs.readFileSync(contextFilename(), 'utf-8').includes('Vector'));
 
-  fs.writeFileSync(contextFilename, '');
+  fs.writeFileSync(contextFilename(), '');
   fs.unlinkSync(file1_abs);
   fs.unlinkSync(file2_abs);
   fs.unlinkSync(file3_abs);

--- a/tests/context_recovery.test.js
+++ b/tests/context_recovery.test.js
@@ -14,14 +14,14 @@ async function run() {
 
   const res = await auto_recover_context();
   assert.ok(res && res.files.includes(rel));
-  assert.ok(fs.readFileSync(contextFilename, 'utf-8').includes('Temp'));
+  assert.ok(fs.readFileSync(contextFilename(), 'utf-8').includes('Temp'));
 
   const manual = await load_memory_to_context(rel);
   assert.ok(manual.tokens >= 1);
 
   // cleanup
   // note: file kept to avoid race with async index rebuild
-  fs.writeFileSync(contextFilename, '');
+  fs.writeFileSync(contextFilename(), '');
   console.log('context recovery tests passed');
 }
 

--- a/tests/periodic_context_check.test.js
+++ b/tests/periodic_context_check.test.js
@@ -6,13 +6,13 @@ const restore_utils = require('../utils/restore_context');
 const { contextFilename } = require('../logic/memory_operations');
 
 (async function run(){
-  fs.writeFileSync(contextFilename, '');
+  fs.writeFileSync(contextFilename(), '');
   const origRestore = restore_utils.restoreContext;
   let called = false;
   restore_utils.restoreContext = async (id) => { called = id === 'testUser'; };
   await router._check_context_for_user('testUser');
   restore_utils.restoreContext = origRestore;
-  fs.writeFileSync(contextFilename, '');
+  fs.writeFileSync(contextFilename(), '');
   assert.ok(called, 'restoreContext should be called when context missing');
   console.log('periodic context check test passed');
 })();

--- a/utils/context_checker.js
+++ b/utils/context_checker.js
@@ -14,7 +14,7 @@ const PORT = process.env.PORT || 10000;
 
 function context_exists() {
   try {
-    const data = fs.readFileSync(contextFilename, 'utf-8');
+    const data = fs.readFileSync(contextFilename(), 'utf-8');
     return data.trim().length > 0;
   } catch {
     return false;

--- a/utils/memory_mode.js
+++ b/utils/memory_mode.js
@@ -1,11 +1,61 @@
+const fs = require('fs');
+const fsp = fs.promises;
 const path = require('path');
 
-function isLocalMode() {
-  return (process.env.MEMORY_MODE || 'github').toLowerCase() === 'local';
+const usersDir = path.join(__dirname, '..', 'config', 'users');
+const cache = {};
+
+function configPath(userId) {
+  return path.join(usersDir, `${userId}.json`);
+}
+
+async function ensureDir() {
+  await fsp.mkdir(usersDir, { recursive: true });
+}
+
+async function getMemoryMode(userId = 'default') {
+  await ensureDir();
+  if (Object.prototype.hasOwnProperty.call(cache, userId)) {
+    return cache[userId];
+  }
+  try {
+    const raw = await fsp.readFile(configPath(userId), 'utf-8');
+    const parsed = JSON.parse(raw);
+    cache[userId] = (parsed.memory_mode || 'github').toLowerCase();
+  } catch {
+    cache[userId] = 'github';
+  }
+  return cache[userId];
+}
+
+function getMemoryModeSync(userId = 'default') {
+  if (!fs.existsSync(usersDir)) fs.mkdirSync(usersDir, { recursive: true });
+  if (Object.prototype.hasOwnProperty.call(cache, userId)) {
+    return cache[userId];
+  }
+  try {
+    const raw = fs.readFileSync(configPath(userId), 'utf-8');
+    const parsed = JSON.parse(raw);
+    cache[userId] = (parsed.memory_mode || 'github').toLowerCase();
+  } catch {
+    cache[userId] = 'github';
+  }
+  return cache[userId];
+}
+
+async function setMemoryMode(userId = 'default', mode = 'github') {
+  mode = (mode || 'github').toLowerCase();
+  await ensureDir();
+  await fsp.writeFile(configPath(userId), JSON.stringify({ memory_mode: mode }, null, 2));
+  cache[userId] = mode;
+}
+
+function isLocalMode(userId = 'default') {
+  return getMemoryModeSync(userId) === 'local';
 }
 
 function baseDir(userId = 'default') {
-  if (isLocalMode()) {
+  if (isLocalMode(userId)) {
     return path.join(__dirname, '..', 'local_memory', userId);
   }
   return path.join(__dirname, '..');
@@ -15,4 +65,11 @@ function resolvePath(relPath, userId = 'default') {
   return path.join(baseDir(userId), relPath);
 }
 
-module.exports = { isLocalMode, baseDir, resolvePath };
+module.exports = {
+  getMemoryMode,
+  getMemoryModeSync,
+  setMemoryMode,
+  isLocalMode,
+  baseDir,
+  resolvePath,
+};


### PR DESCRIPTION
## Summary
- support storing memory mode per user with helper functions
- expose new route `POST /memory/set-mode`
- document the API in OpenAPI specs
- adjust storage paths and constants to update based on current memory mode
- update tests for new helper

## Testing
- `npm test` *(fails: Cannot find module 'ajv')*

------
https://chatgpt.com/codex/tasks/task_e_686389c916588323a47ea083bc82f1a2