### PR TITLE
Improve repo existence check

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ npm test
 - `POST /save` \u2014 сохранить файл в репозитории;
 - `POST /read` \u2014 прочитать содержимое файла;
 - `POST /saveMemory` и `POST /readMemory` \u2014 работа с основной памятью;
-- При сохранении через `POST /saveMemory` перед записью проверяется GitHub токен
-  и существование репозитория. Неверный токен приводит к ответу `401`,
-  отсутствующий репозиторий — к `404`. В этих случаях запись в GitHub не
+- При сохранении через `POST /saveMemory` и `POST /saveMemoryWithIndex` перед
+  записью проверяется GitHub токен и существование репозитория. Ответ `401`
+  приводит к сообщению «Invalid GitHub token.», `403` \u2014 к «Access denied to
+  repository.», остальные коды \u2014 к «Repository not found.» Запись в GitHub не
   выполняется;
 - `POST /saveMemoryWithIndex` \u2014 сохранить файл и обновить `index.json`;
 - `POST /saveAnswer` \u2014 сохранить эталонный ответ;

--- a/api/memory_routes.js
+++ b/api/memory_routes.js
@@ -122,13 +122,19 @@ async function saveMemory(req, res) {
       return res.status(401).json({ status: 'error', message: 'Invalid GitHub token' });
     }
     try {
-      const exists = await github.repoExists(effectiveToken, effectiveRepo);
+      const { exists, status } = await github.repoExists(effectiveToken, effectiveRepo);
       if (!exists) {
-        return res.status(404).json({ status: 'error', message: 'Repository not found' });
+        if (status === 401) {
+          return res.status(401).json({ status: 'error', message: 'Invalid GitHub token.' });
+        }
+        if (status === 403) {
+          return res.status(403).json({ status: 'error', message: 'Access denied to repository.' });
+        }
+        return res.status(404).json({ status: 'error', message: 'Repository not found.' });
       }
     } catch (e) {
       logError('repoExists', e);
-      return res.status(404).json({ status: 'error', message: 'Repository not found' });
+      return res.status(404).json({ status: 'error', message: 'Repository not found.' });
     }
   }
 
@@ -575,13 +581,19 @@ router.post('/saveMemoryWithIndex', async (req, res) => {
       return res.status(401).json({ status: 'error', message: 'Invalid GitHub token' });
     }
     try {
-      const exists = await github.repoExists(effectiveToken, effectiveRepo);
+      const { exists, status } = await github.repoExists(effectiveToken, effectiveRepo);
       if (!exists) {
-        return res.status(404).json({ status: 'error', message: 'Repository not found' });
+        if (status === 401) {
+          return res.status(401).json({ status: 'error', message: 'Invalid GitHub token.' });
+        }
+        if (status === 403) {
+          return res.status(403).json({ status: 'error', message: 'Access denied to repository.' });
+        }
+        return res.status(404).json({ status: 'error', message: 'Repository not found.' });
       }
     } catch (e) {
       logError('repoExists', e);
-      return res.status(404).json({ status: 'error', message: 'Repository not found' });
+      return res.status(404).json({ status: 'error', message: 'Repository not found.' });
     }
   }
   try {

--- a/tests/saveMemoryWithIndex_retry.test.js
+++ b/tests/saveMemoryWithIndex_retry.test.js
@@ -11,7 +11,7 @@ const github = require('../tools/github_client');
   const origValidate = github.validateToken;
   const origExists = github.repoExists;
   github.validateToken = async () => ({ valid: true });
-  github.repoExists = async () => true;
+  github.repoExists = async () => ({ exists: true });
 
   // mock axios to simulate 5xx errors
   const origGet = axios.get;

--- a/tools/github_client.js
+++ b/tools/github_client.js
@@ -35,10 +35,11 @@ exports.repoExists = async function (token, repo) {
     const res = await axios.get(`https://api.github.com/repos/${normalized}`, {
       headers: { Authorization: `token ${token}`, ...DEFAULT_HEADERS }
     });
-    return res.status === 200;
+    return { exists: res.status === 200 };
   } catch (e) {
+    const status = e.response ? e.response.status : undefined;
     logError('repoExists', e);
-    return false;
+    return { exists: false, status };
   }
 };
 


### PR DESCRIPTION
## Summary
- return status information from `repoExists`
- handle GitHub error codes in `/saveMemory` and `/saveMemoryWithIndex`
- adjust tests for new return type
- document repository access errors in README

## Testing
- `npm test` *(fails: memory_dynamic_index_update.test.js assertion)*

------
https://chatgpt.com/codex/tasks/task_e_6863a5ff51e48323bb0348360adfa324