### PR TITLE
Add retrying repoExistsSafe

### DIFF
--- a/api/memory_routes.js
+++ b/api/memory_routes.js
@@ -122,7 +122,10 @@ async function saveMemory(req, res) {
       return res.status(401).json({ status: 'error', message: 'Invalid GitHub token' });
     }
     try {
-      const { exists, status } = await github.repoExists(effectiveToken, effectiveRepo);
+      const { exists, status } = await github.repoExistsSafe(
+        effectiveToken,
+        effectiveRepo
+      );
       if (!exists) {
         if (status === 401) {
           return res.status(401).json({ status: 'error', message: 'Invalid GitHub token.' });
@@ -581,7 +584,10 @@ router.post('/saveMemoryWithIndex', async (req, res) => {
       return res.status(401).json({ status: 'error', message: 'Invalid GitHub token' });
     }
     try {
-      const { exists, status } = await github.repoExists(effectiveToken, effectiveRepo);
+      const { exists, status } = await github.repoExistsSafe(
+        effectiveToken,
+        effectiveRepo
+      );
       if (!exists) {
         if (status === 401) {
           return res.status(401).json({ status: 'error', message: 'Invalid GitHub token.' });

--- a/tests/repoExistsSafe_retry.test.js
+++ b/tests/repoExistsSafe_retry.test.js
@@ -1,0 +1,23 @@
+process.env.NO_GIT = "true";
+const assert = require('assert');
+const axios = require('axios');
+const github = require('../tools/github_client');
+
+(async function run(){
+  const origGet = axios.get;
+  let attempts = 0;
+  axios.get = async () => {
+    attempts++;
+    const err = new Error('fail');
+    err.response = { status: 503, data: { message: 'Server Error' } };
+    throw err;
+  };
+
+  const res = await github.repoExistsSafe('tok','user/repo',3);
+  assert.ok(attempts > 1, 'repoExistsSafe should retry on failure');
+  assert.strictEqual(res.exists, false);
+  assert.strictEqual(res.status, 503);
+
+  axios.get = origGet;
+  console.log('repoExistsSafe retry test passed');
+})();


### PR DESCRIPTION
## Summary
- implement `repoExistsSafe` in GitHub client with exponential backoff
- use `repoExistsSafe` in memory routes
- add regression test for retry behaviour

## Testing
- `node tests/repoExistsSafe_retry.test.js`
- `npm test` *(fails: memory_dynamic_index_update.test)*

------
https://chatgpt.com/codex/tasks/task_e_6863b37b9c7c8323a27e24dd2683dfd0