### PR TITLE
Add local memory path commands

### DIFF
--- a/src/memory.js
+++ b/src/memory.js
@@ -9,7 +9,14 @@ const memory_config = require('../tools/memory_config');
 const token_store = require('../tools/token_store');
 const { normalize_memory_path } = require('../tools/file_utils');
 const path = require('path');
-const { isLocalMode, baseDir } = require('../utils/memory_mode');
+const {
+  isLocalMode,
+  baseDir,
+  setMemoryMode,
+  setLocalPath,
+  setMemoryFolder,
+  switchLocalRepo,
+} = require('../utils/memory_mode');
 function getRootDir(userId = 'default') {
   return isLocalMode(userId) ? baseDir(userId) : path.join(__dirname, '..');
 }
@@ -191,6 +198,24 @@ async function setMemoryRepo(token, repo) {
     logger.error('[setMemoryRepo] error', e.message);
     throw e;
   }
+}
+
+async function setLocalMemoryPath(dir, userId = 'default') {
+  await setLocalPath(userId, dir);
+  await setMemoryMode(userId, 'local');
+}
+
+async function createMemoryFolder(name, userId = 'default') {
+  await setMemoryFolder(userId, name);
+}
+
+async function switchMemoryRepo(type, dir, userId = 'default') {
+  const mode = (type || '').toLowerCase();
+  if (mode === 'local') {
+    await switchLocalRepo(userId, dir);
+    return { mode: 'local' };
+  }
+  throw new Error('Unsupported repo type');
 }
 
 async function refreshContextFromMemoryFiles(repo, token, keywords = []) {
@@ -490,4 +515,7 @@ module.exports = {
   checkAndRestoreContext,
   getTokenCounter,
   formatTokenCounter,
+  setLocalMemoryPath,
+  createMemoryFolder,
+  switchMemoryRepo,
 };

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -62,9 +62,33 @@ function parse_manual_load_command(message = '') {
   return { path: m[1] };
 }
 
+function parse_set_local_path(message = '') {
+  if (typeof message !== 'string') return null;
+  const m = message.match(/\/set_local_path\s+path="([^"]+)"/i);
+  if (!m) return null;
+  return { path: m[1] };
+}
+
+function parse_set_memory_folder(message = '') {
+  if (typeof message !== 'string') return null;
+  const m = message.match(/\/set_memory_folder\s+name="([^"]+)"/i);
+  if (!m) return null;
+  return { name: m[1] };
+}
+
+function parse_switch_memory_repo(message = '') {
+  if (typeof message !== 'string') return null;
+  const m = message.match(/\/switch_memory_repo\s+type=(\w+)\s+path="([^"]+)"/i);
+  if (!m) return null;
+  return { type: m[1], path: m[2] };
+}
+
 module.exports = {
   parse_user_memory_setup,
   parse_save_reference_answer,
-  parse_manual_load_command
+  parse_manual_load_command,
+  parse_set_local_path,
+  parse_set_memory_folder,
+  parse_switch_memory_repo,
 };
 


### PR DESCRIPTION
## Summary
- extend helpers with parsers for `/set_local_path`, `/set_memory_folder` and `/switch_memory_repo`
- implement local path handling in `memory_mode`
- expose new memory management functions in `src/memory.js`

## Testing
- `npm test` *(fails: Command failed: node /workspace/sofia-memory-plugin/tests/memory_dynamic_index_update.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6863bc5659c483238173a2f80527eb44