### PR TITLE
Add memory folder switch logic

### DIFF
--- a/.sofia/config.json
+++ b/.sofia/config.json
@@ -1,0 +1,1 @@
+{"active_folder":null}

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -76,6 +76,18 @@ function parse_set_memory_folder(message = '') {
   return { name: m[1] };
 }
 
+function parse_switch_memory_folder(message = '') {
+  if (typeof message !== 'string') return null;
+  const m = message.match(/\/switch_memory_folder\s+name="([^"]+)"/i);
+  if (!m) return null;
+  return { name: m[1] };
+}
+
+function parse_list_memory_folders(message = '') {
+  if (typeof message !== 'string') return null;
+  return /\/list_memory_folders/i.test(message) ? {} : null;
+}
+
 function parse_switch_memory_repo(message = '') {
   if (typeof message !== 'string') return null;
   const m = message.match(/\/switch_memory_repo\s+type=(\w+)\s+path="([^"]+)"/i);
@@ -89,6 +101,8 @@ module.exports = {
   parse_manual_load_command,
   parse_set_local_path,
   parse_set_memory_folder,
+  parse_switch_memory_folder,
+  parse_list_memory_folders,
   parse_switch_memory_repo,
 };
 


### PR DESCRIPTION
## Summary
- enable active folder config in `.sofia/config.json`
- parse `/switch_memory_folder` and `/list_memory_folders` commands
- expose new memory folder utilities

## Testing
- `npm test` *(fails: Cannot find module 'ajv', assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_6863ccfe9c7083238d0a9111fe29198e