### PR TITLE
Add memory folder creation command

### DIFF
--- a/api/memory_routes.js
+++ b/api/memory_routes.js
@@ -683,6 +683,22 @@ router.post('/chat/setup', async (req, res) => {
   const { userId, repo } = parsed;
   res.json({ status: 'success', message: `Memory configured for user: ${userId}`, repo });
 });
+
+router.post('/chat/create_memory_folder', async (req, res) => {
+  const text = req.body && req.body.text ? req.body.text : '';
+  const { parse_create_memory_folder } = require('../utils/helpers');
+  const { createMemoryFolder } = require('../src/memory');
+  const parsed = parse_create_memory_folder(text);
+  if (!parsed)
+    return res.status(400).json({ status: 'error', message: 'Invalid command' });
+  const { name, init_index } = parsed;
+  try {
+    await createMemoryFolder(name, init_index);
+    res.json({ status: 'success', folder: name });
+  } catch (e) {
+    res.status(500).json({ status: 'error', message: e.message });
+  }
+});
 router.post('/updateIndex', updateIndexManual);
 router.get('/plan', readPlan);
 router.get('/profile', readProfile);

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -211,6 +211,22 @@ paths:
       responses:
         '200':
           description: Setup parsed
+  /chat/create_memory_folder:
+    post:
+      summary: Create memory folder
+      operationId: chatCreateMemoryFolder
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                text:
+                  type: string
+      responses:
+        '200':
+          description: Folder created
   /updateIndex:
     post:
       summary: Manually update index entries

--- a/openapi_template.yaml
+++ b/openapi_template.yaml
@@ -211,6 +211,22 @@ paths:
       responses:
         '200':
           description: Setup parsed
+  /chat/create_memory_folder:
+    post:
+      summary: Create memory folder
+      operationId: chatCreateMemoryFolder
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                text:
+                  type: string
+      responses:
+        '200':
+          description: Folder created
   /updateIndex:
     post:
       summary: Manually update index entries

--- a/src/memory.js
+++ b/src/memory.js
@@ -205,8 +205,18 @@ async function setLocalMemoryPath(dir, userId = 'default') {
   await setMemoryMode(userId, 'local');
 }
 
-async function createMemoryFolder(name, userId = 'default') {
+async function createMemoryFolder(name, initIndex = false, userId = 'default') {
   await setMemoryFolder(userId, name);
+  if (initIndex) {
+    const dir = path.join(baseDir(userId), 'memory');
+    await fsp.mkdir(dir, { recursive: true });
+    const indexPath = path.join(dir, 'index.json');
+    const planPath = path.join(dir, 'plan.md');
+    const configPath = path.join(dir, 'config.json');
+    if (!fs.existsSync(indexPath)) await fsp.writeFile(indexPath, '');
+    if (!fs.existsSync(planPath)) await fsp.writeFile(planPath, '');
+    if (!fs.existsSync(configPath)) await fsp.writeFile(configPath, '{}');
+  }
 }
 
 async function switchMemoryRepo(type, dir, userId = 'default') {

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -95,6 +95,13 @@ function parse_switch_memory_repo(message = '') {
   return { type: m[1], path: m[2] };
 }
 
+function parse_create_memory_folder(message = '') {
+  if (typeof message !== 'string') return null;
+  const m = message.match(/\/create_memory_folder\s+name="([^"]+)"(?:\s+init_index=(true|false))?/i);
+  if (!m) return null;
+  return { name: m[1], init_index: m[2] ? m[2].toLowerCase() === 'true' : false };
+}
+
 module.exports = {
   parse_user_memory_setup,
   parse_save_reference_answer,
@@ -104,5 +111,6 @@ module.exports = {
   parse_switch_memory_folder,
   parse_list_memory_folders,
   parse_switch_memory_repo,
+  parse_create_memory_folder,
 };
 


### PR DESCRIPTION
## Summary
- implement `/create_memory_folder` command parser
- create helper function to initialize memory folder with optional files
- expose new chat route and document in OpenAPI spec

## Testing
- `npm install`
- `npm test` *(fails: Cannot find module 'ajv' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6863dac082c483239a1d043469250d4a