### PR TITLE
Add load_memory command

### DIFF
--- a/api/memory_routes.js
+++ b/api/memory_routes.js
@@ -699,6 +699,22 @@ router.post('/chat/create_memory_folder', async (req, res) => {
     res.status(500).json({ status: 'error', message: e.message });
   }
 });
+
+router.post('/chat/load_memory', async (req, res) => {
+  const text = req.body && req.body.text ? req.body.text : '';
+  const { parse_load_memory } = require('../utils/helpers');
+  const { switchMemoryFolder } = require('../utils/memory_mode');
+  const parsed = parse_load_memory(text);
+  if (!parsed)
+    return res.status(400).json({ status: 'error', message: 'Invalid command' });
+  const { name } = parsed;
+  try {
+    const { index, plan } = await switchMemoryFolder('default', name);
+    res.json({ status: 'success', folder: name, index, plan });
+  } catch (e) {
+    res.status(500).json({ status: 'error', message: e.message });
+  }
+});
 router.post('/updateIndex', updateIndexManual);
 router.get('/plan', readPlan);
 router.get('/profile', readProfile);

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -227,6 +227,22 @@ paths:
       responses:
         '200':
           description: Folder created
+  /chat/load_memory:
+    post:
+      summary: Load memory folder
+      operationId: chatLoadMemory
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                text:
+                  type: string
+      responses:
+        '200':
+          description: Memory loaded
   /updateIndex:
     post:
       summary: Manually update index entries

--- a/openapi_template.yaml
+++ b/openapi_template.yaml
@@ -227,6 +227,22 @@ paths:
       responses:
         '200':
           description: Folder created
+  /chat/load_memory:
+    post:
+      summary: Load memory folder
+      operationId: chatLoadMemory
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                text:
+                  type: string
+      responses:
+        '200':
+          description: Memory loaded
   /updateIndex:
     post:
       summary: Manually update index entries

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -102,6 +102,13 @@ function parse_create_memory_folder(message = '') {
   return { name: m[1], init_index: m[2] ? m[2].toLowerCase() === 'true' : false };
 }
 
+function parse_load_memory(message = '') {
+  if (typeof message !== 'string') return null;
+  const m = message.match(/\/load_memory\s+name="([^"]+)"/i);
+  if (!m) return null;
+  return { name: m[1] };
+}
+
 module.exports = {
   parse_user_memory_setup,
   parse_save_reference_answer,
@@ -112,5 +119,6 @@ module.exports = {
   parse_list_memory_folders,
   parse_switch_memory_repo,
   parse_create_memory_folder,
+  parse_load_memory,
 };
 


### PR DESCRIPTION
## Summary
- allow switching local memory folder via `/chat/load_memory`
- document the new command in OpenAPI specification
- parse `/load_memory` in helper utilities

## Testing
- `npm run build:openapi`
- `npm test` *(fails: memory_dynamic_index_update.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6863dde437148323a9f86f165d6d23f2