### PR TITLE
Add switch_memory_repo endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ const memory_routes = require("./api/memory_routes");
 const github_routes = require("./api/github_routes");
 const { listMemoryFiles } = require("./logic/memory_operations");
 const versioning = require('./versioning');
+const memory_mode = require('./utils/memory_mode');
 
 const app = express();
 try {
@@ -46,6 +47,18 @@ app.get('/ai-plugin.json', (_req, res) => {
 app.use(bodyParser.json());
 app.use(memory_routes);
 app.use(github_routes);
+
+app.post('/switch_memory_repo', (req, res) => {
+  const { type, path, repo, token, userId } = req.body;
+  try {
+    const config = { type, path, repo, token, userId };
+    memory_mode.setMode(type, config);
+    res.status(200).json({ status: 'OK', mode: type });
+  } catch (err) {
+    console.error('Ошибка при переключении режима:', err);
+    res.status(500).json({ error: err.message });
+  }
+});
 
 app.post('/list', async (req, res) => {
   try {
@@ -105,6 +118,7 @@ app.get('/docs', (req, res) => {
         "POST /readMemory",
         "POST /read",
         "POST /setMemoryRepo",
+        "POST /switch_memory_repo",
         "POST /saveLessonPlan",
         "POST /saveMemoryWithIndex",
         "POST /saveNote",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -70,6 +70,31 @@ paths:
           description: Mode stored
         '400':
           description: Invalid mode
+  /switch_memory_repo:
+    post:
+      summary: Switch memory storage mode
+      operationId: switch_memory_repo
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum: [local, github]
+                path:
+                  type: string
+                repo:
+                  type: string
+                token:
+                  type: string
+                userId:
+                  type: string
+      responses:
+        "200":
+          description: Memory mode switched
   /saveLessonPlan:
     post:
       summary: Update learning plan

--- a/openapi_template.yaml
+++ b/openapi_template.yaml
@@ -70,6 +70,31 @@ paths:
           description: Mode stored
         '400':
           description: Invalid mode
+  /switch_memory_repo:
+    post:
+      summary: Switch memory storage mode
+      operationId: switch_memory_repo
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum: [local, github]
+                path:
+                  type: string
+                repo:
+                  type: string
+                token:
+                  type: string
+                userId:
+                  type: string
+      responses:
+        "200":
+          description: Memory mode switched
   /saveLessonPlan:
     post:
       summary: Update learning plan

--- a/utils/memory_mode.js
+++ b/utils/memory_mode.js
@@ -209,6 +209,19 @@ async function switchMemoryFolder(userId = 'default', name) {
   return { index, plan };
 }
 
+function setMode(type, config = {}) {
+  if (type === 'local') {
+    process.env.MEMORY_MODE = 'local';
+    process.env.LOCAL_PATH = config.path || '';
+  } else if (type === 'github') {
+    process.env.MEMORY_MODE = 'github';
+    process.env.REPO = config.repo;
+    process.env.TOKEN = config.token;
+  } else {
+    throw new Error('Unknown memory mode: ' + type);
+  }
+}
+
 module.exports = {
   getMemoryMode,
   getMemoryModeSync,
@@ -225,4 +238,5 @@ module.exports = {
   switchMemoryFolder,
   getActiveMemoryFolder,
   getAgentBaseUrl,
+  setMode,
 };


### PR DESCRIPTION
## Summary
- enable switching memory repository via `/switch_memory_repo` route
- document new endpoint in OpenAPI spec
- expose new `setMode` helper to switch environment variables

## Testing
- `npm test` *(fails: Cannot find module 'ajv')*
- `npm run build:openapi` *(fails: Cannot find module 'js-yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68658942429483238f05c07c62347db5