### PR TITLE
Enable Desktop Agent with fixed endpoint

### DIFF
--- a/src/memory.js
+++ b/src/memory.js
@@ -16,7 +16,6 @@ const {
   setLocalPath,
   setMemoryFolder,
   switchLocalRepo,
-  getAgentBaseUrl,
 } = require('../utils/memory_mode');
 const { requestToAgent } = require('./memory_plugin');
 function getRootDir(userId = 'default') {

--- a/src/memory_plugin.js
+++ b/src/memory_plugin.js
@@ -1,8 +1,7 @@
 const axios = require('axios');
-const { getAgentBaseUrl } = require('../utils/memory_mode');
 
 async function requestToAgent(endpoint, method = 'GET', data = {}) {
-  const baseUrl = getAgentBaseUrl();
+  const baseUrl = 'http://localhost:4465';
   try {
     const response = await axios({
       method,


### PR DESCRIPTION
## Summary
- route requests to the local Desktop Agent through a helper
- clean up unused memory agent URL import

## Testing
- `npm test` *(fails: Cannot find module 'ajv')*

------
https://chatgpt.com/codex/tasks/task_e_686592dcb4c083238ed5542f43eacb15