### PR TITLE
Add GET route for switching memory repository

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,18 @@ app.post('/switch_memory_repo', async (req, res) => {
   }
 });
 
+// Route to switch memory repository via query parameter
+app.get('/api/switch_memory_repo', async (req, res) => {
+  const { type, userId } = req.query;
+  try {
+    const result = await switchMemoryRepo(type, undefined, userId);
+    res.status(200).json({ status: 'ok', mode: result.mode });
+  } catch (err) {
+    console.error('Ошибка при переключении режима:', err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
 app.post('/list', async (req, res) => {
   try {
     const { repo, token, path: dirPath } = req.body;
@@ -117,6 +129,7 @@ app.get('/docs', (req, res) => {
         "POST /read",
         "POST /setMemoryRepo",
         "POST /switch_memory_repo",
+        "GET /api/switch_memory_repo",
         "POST /saveLessonPlan",
         "POST /saveMemoryWithIndex",
         "POST /saveNote",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -95,6 +95,23 @@ paths:
       responses:
         "200":
           description: Memory mode switched
+  /api/switch_memory_repo:
+    get:
+      summary: Switch memory storage mode
+      operationId: switch_memory_repo_get
+      parameters:
+        - in: query
+          name: type
+          schema:
+            type: string
+            enum: [local, github]
+        - in: query
+          name: userId
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Memory mode switched
   /saveLessonPlan:
     post:
       summary: Update learning plan

--- a/openapi_template.yaml
+++ b/openapi_template.yaml
@@ -95,6 +95,23 @@ paths:
       responses:
         "200":
           description: Memory mode switched
+  /api/switch_memory_repo:
+    get:
+      summary: Switch memory storage mode
+      operationId: switch_memory_repo_get
+      parameters:
+        - in: query
+          name: type
+          schema:
+            type: string
+            enum: [local, github]
+        - in: query
+          name: userId
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Memory mode switched
   /saveLessonPlan:
     post:
       summary: Update learning plan


### PR DESCRIPTION
## Summary
- add `GET /api/switch_memory_repo` to toggle memory mode
- document the new endpoint in `openapi_template.yaml`
- regenerate `openapi.yaml`

## Testing
- `npm test` *(fails: AssertionError)*
- `npm run build:openapi`

------
https://chatgpt.com/codex/tasks/task_e_6867dd391d88832399cd46d7a9a7dbca