### PR TITLE
Add API status endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ const memory_routes = require("./api/memory_routes");
 const github_routes = require("./api/github_routes");
 const { listMemoryFiles } = require("./logic/memory_operations");
 const versioning = require('./versioning');
+const { getMemoryModeSync } = require('./utils/memory_mode');
 
 const app = express();
 try {
@@ -68,6 +69,12 @@ app.get('/api/switch_memory_repo', async (req, res) => {
     console.error('Ошибка при переключении режима:', err);
     res.status(500).json({ error: err.message });
   }
+});
+
+app.get('/api/status', (req, res) => {
+  const userId = req.query.userId || 'default';
+  const mode = getMemoryModeSync(userId);
+  res.json({ mode });
 });
 
 app.post('/list', async (req, res) => {
@@ -130,6 +137,7 @@ app.get('/docs', (req, res) => {
         "POST /setMemoryRepo",
         "POST /switch_memory_repo",
         "GET /api/switch_memory_repo",
+        "GET /api/status",
         "POST /saveLessonPlan",
         "POST /saveMemoryWithIndex",
         "POST /saveNote",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -112,6 +112,18 @@ paths:
       responses:
         "200":
           description: Memory mode switched
+  /api/status:
+    get:
+      summary: Get current memory mode
+      operationId: status
+      parameters:
+        - in: query
+          name: userId
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Current mode
   /saveLessonPlan:
     post:
       summary: Update learning plan

--- a/openapi_template.yaml
+++ b/openapi_template.yaml
@@ -112,6 +112,18 @@ paths:
       responses:
         "200":
           description: Memory mode switched
+  /api/status:
+    get:
+      summary: Get current memory mode
+      operationId: status
+      parameters:
+        - in: query
+          name: userId
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Current mode
   /saveLessonPlan:
     post:
       summary: Update learning plan


### PR DESCRIPTION
## Summary
- expose `GET /api/status` route
- document `/api/status` in OpenAPI templates
- rebuild `openapi.yaml`

## Testing
- `npm run build:openapi`
- `npm test` *(fails: AssertionError in memory_dynamic_index_update.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6867dfd091b4832391351b695ebb58bb