### PR TITLE
Add global memory mode management

### DIFF
--- a/api/mode_routes.js
+++ b/api/mode_routes.js
@@ -1,0 +1,23 @@
+const express = require('express');
+const router = express.Router();
+const {
+  getMemoryModeSync,
+  setMemoryMode,
+} = require('../src/memory_mode');
+
+router.get('/memory-mode', (req, res) => {
+  const mode = getMemoryModeSync();
+  res.json({ mode });
+});
+
+router.post('/memory-mode', async (req, res) => {
+  const { mode } = req.body || {};
+  const val = (mode || '').toLowerCase();
+  if (!['local', 'github'].includes(val)) {
+    return res.status(400).json({ status: 'error', message: 'Invalid mode' });
+  }
+  await setMemoryMode(val);
+  res.json({ status: 'success', mode: val });
+});
+
+module.exports = router;

--- a/api/openapi_lite.yaml
+++ b/api/openapi_lite.yaml
@@ -70,6 +70,31 @@ paths:
           description: Mode stored
         '400':
           description: Invalid mode
+  /memory-mode:
+    get:
+      summary: Get global memory mode
+      operationId: getGlobalMemoryMode
+      responses:
+        '200':
+          description: Current global mode
+    post:
+      summary: Set global memory mode
+      operationId: setGlobalMemoryMode
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                mode:
+                  type: string
+                  enum: [local, github]
+      responses:
+        '200':
+          description: Mode stored
+        '400':
+          description: Invalid mode
   /saveLessonPlan:
     post:
       summary: Update learning plan

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -124,6 +124,31 @@ paths:
       responses:
         '200':
           description: Current mode
+  /memory-mode:
+    get:
+      summary: Get global memory mode
+      operationId: getGlobalMemoryMode
+      responses:
+        '200':
+          description: Current global mode
+    post:
+      summary: Set global memory mode
+      operationId: setGlobalMemoryMode
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                mode:
+                  type: string
+                  enum: [local, github]
+      responses:
+        '200':
+          description: Mode stored
+        '400':
+          description: Invalid mode
   /saveLessonPlan:
     post:
       summary: Update learning plan

--- a/openapi_template.yaml
+++ b/openapi_template.yaml
@@ -124,6 +124,31 @@ paths:
       responses:
         '200':
           description: Current mode
+  /memory-mode:
+    get:
+      summary: Get global memory mode
+      operationId: getGlobalMemoryMode
+      responses:
+        '200':
+          description: Current global mode
+    post:
+      summary: Set global memory mode
+      operationId: setGlobalMemoryMode
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                mode:
+                  type: string
+                  enum: [local, github]
+      responses:
+        '200':
+          description: Mode stored
+        '400':
+          description: Invalid mode
   /saveLessonPlan:
     post:
       summary: Update learning plan

--- a/src/memory_mode.js
+++ b/src/memory_mode.js
@@ -1,0 +1,64 @@
+const fs = require('fs');
+const fsp = fs.promises;
+const path = require('path');
+
+const cfgDir = path.join(__dirname, '..', 'config', '.sofia');
+const cfgPath = path.join(cfgDir, 'config.json');
+
+function loadConfigSync() {
+  try {
+    const raw = fs.readFileSync(cfgPath, 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+}
+
+async function loadConfig() {
+  try {
+    const raw = await fsp.readFile(cfgPath, 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+}
+
+function saveConfigSync(cfg) {
+  fs.mkdirSync(cfgDir, { recursive: true });
+  fs.writeFileSync(cfgPath, JSON.stringify(cfg, null, 2));
+}
+
+async function saveConfig(cfg) {
+  await fsp.mkdir(cfgDir, { recursive: true });
+  await fsp.writeFile(cfgPath, JSON.stringify(cfg, null, 2));
+}
+
+function getMemoryModeSync() {
+  const cfg = loadConfigSync();
+  return (cfg.memory_mode || 'github').toLowerCase();
+}
+
+async function getMemoryMode() {
+  const cfg = await loadConfig();
+  return (cfg.memory_mode || 'github').toLowerCase();
+}
+
+function setMemoryModeSync(mode = 'github') {
+  const cfg = loadConfigSync();
+  cfg.memory_mode = (mode || 'github').toLowerCase();
+  saveConfigSync(cfg);
+}
+
+async function setMemoryMode(mode = 'github') {
+  const cfg = await loadConfig();
+  cfg.memory_mode = (mode || 'github').toLowerCase();
+  await saveConfig(cfg);
+}
+
+module.exports = {
+  getMemoryMode,
+  getMemoryModeSync,
+  setMemoryMode,
+  setMemoryModeSync,
+  configPath: cfgPath,
+};

--- a/tests/global_memory_mode.test.js
+++ b/tests/global_memory_mode.test.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const { getMemoryMode, setMemoryMode, configPath } = require('../src/memory_mode');
+
+(async function run() {
+  const dir = path.dirname(configPath);
+  fs.rmSync(dir, { recursive: true, force: true });
+
+  let mode = await getMemoryMode();
+  assert.strictEqual(mode, 'github');
+
+  await setMemoryMode('local');
+  mode = await getMemoryMode();
+  assert.strictEqual(mode, 'local');
+
+  await setMemoryMode('github');
+  mode = await getMemoryMode();
+  assert.strictEqual(mode, 'github');
+
+  fs.rmSync(dir, { recursive: true, force: true });
+  console.log('global memory mode tests passed');
+})();


### PR DESCRIPTION
## Summary
- provide `src/memory_mode.js` with getters and setters for a global memory mode stored in `config/.sofia/config.json`
- expose API endpoints `/memory-mode` for reading/updating this value
- document the new endpoints in OpenAPI specs
- cover behaviour with a unit test

## Testing
- `npm test` *(fails: AssertionError in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6867e242417c8323b6fdb38eadda36b3