### PR TITLE
Add API test for switching memory mode

### DIFF
--- a/src/memory.js
+++ b/src/memory.js
@@ -232,7 +232,11 @@ async function createMemoryFolder(name, initIndex = false, userId = 'default') {
 async function switchMemoryRepo(type, dir, userId = 'default') {
   const mode = (type || '').toLowerCase();
   if (mode === 'local') {
-    await switchLocalRepo(userId, dir);
+    const target = dir || path.join(
+      process.env.LOCAL_MEMORY_PATH || path.join(__dirname, '..', 'local_memory'),
+      userId
+    );
+    await switchLocalRepo(userId, target);
     return { mode: 'local' };
   }
   throw new Error('Unsupported repo type');

--- a/tests/memory_mode_api.test.js
+++ b/tests/memory_mode_api.test.js
@@ -1,0 +1,37 @@
+process.env.NO_GIT = 'true';
+const { spawn } = require('child_process');
+const path = require('path');
+const axios = require('axios');
+const assert = require('assert');
+const { setMemoryMode } = require('../utils/memory_mode');
+
+async function waitForServer(port) {
+  for (let i = 0; i < 20; i++) {
+    try {
+      await axios.get(`http://localhost:${port}/ping`);
+      return;
+    } catch {
+      await new Promise(r => setTimeout(r, 200));
+    }
+  }
+  throw new Error('server did not start');
+}
+
+(async function run(){
+  const PORT = 15000;
+  const env = { ...process.env, PORT: String(PORT) };
+  const server = spawn('node', [path.join(__dirname, '..', 'index.js')], { env, stdio: 'inherit' });
+  try {
+    await waitForServer(PORT);
+    const res = await axios.get(`http://localhost:${PORT}/api/switch_memory_repo`, { params: { type: 'local' } });
+    assert.deepStrictEqual(res.data, { status: 'ok', mode: 'local' });
+
+    const status = await axios.get(`http://localhost:${PORT}/api/status`);
+    assert.strictEqual(status.data.mode, 'local');
+
+    console.log('memory mode api tests passed');
+  } finally {
+    server.kill();
+    await setMemoryMode('default', 'github');
+  }
+})();


### PR DESCRIPTION
## Summary
- test API for switching memory repo via GET endpoint
- default to a usable path when switching memory repository

## Testing
- `npm test` *(fails: memory_dynamic_index_update.test.js assertion)*

------
https://chatgpt.com/codex/tasks/task_e_6867e52809e48323a514571a276a3dc3