### PR TITLE
Fix IndexEntry schema in OpenAPI specs

### DIFF
--- a/api/openapi_lite.yaml
+++ b/api/openapi_lite.yaml
@@ -352,6 +352,19 @@ components:
           type: string
         path:
           type: string
+    IndexEntry:
+      type: object
+      properties:
+        path:
+          type: string
+        title:
+          type: string
+        type:
+          type: string
+        description:
+          type: string
+        lastModified:
+          type: string
     UpdateIndexRequest:
       type: object
       properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -352,6 +352,19 @@ components:
           type: string
         path:
           type: string
+    IndexEntry:
+      type: object
+      properties:
+        path:
+          type: string
+        title:
+          type: string
+        type:
+          type: string
+        description:
+          type: string
+        lastModified:
+          type: string
     UpdateIndexRequest:
       type: object
       properties:

--- a/openapi_template.yaml
+++ b/openapi_template.yaml
@@ -352,6 +352,19 @@ components:
           type: string
         path:
           type: string
+    IndexEntry:
+      type: object
+      properties:
+        path:
+          type: string
+        title:
+          type: string
+        type:
+          type: string
+        description:
+          type: string
+        lastModified:
+          type: string
     UpdateIndexRequest:
       type: object
       properties:


### PR DESCRIPTION
## Summary
- add missing `IndexEntry` schema under `components.schemas`
- regenerate OpenAPI file
- sync lite specification

## Testing
- `npm run build:openapi`
- `npm test` *(fails: AssertionError in memory_dynamic_index_update.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6867f04edb148323a02435e2eaade864