### PR TITLE
Fix memory mode switching

### DIFF
--- a/api/mode_routes.js
+++ b/api/mode_routes.js
@@ -4,6 +4,7 @@ const {
   getMemoryModeSync,
   setMemoryMode,
 } = require('../src/memory_mode');
+const { setLocalPath } = require('../utils/memory_mode');
 
 router.get('/memory-mode', (req, res) => {
   const mode = getMemoryModeSync();
@@ -18,6 +19,19 @@ router.post('/memory-mode', async (req, res) => {
   }
   await setMemoryMode(val);
   res.json({ status: 'success', mode: val });
+});
+
+router.post('/local-path', async (req, res) => {
+  const { path, userId } = req.body || {};
+  if (!path) {
+    return res.status(400).json({ status: 'error', message: 'Missing path' });
+  }
+  try {
+    await setLocalPath(userId || 'default', path);
+    res.json({ status: 'success', path });
+  } catch (e) {
+    res.status(500).json({ status: 'error', message: e.message });
+  }
 });
 
 module.exports = router;

--- a/api/openapi_lite.yaml
+++ b/api/openapi_lite.yaml
@@ -95,6 +95,26 @@ paths:
           description: Mode stored
         '400':
           description: Invalid mode
+  /local-path:
+    post:
+      summary: Set local storage path
+      operationId: setLocalPath
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                path:
+                  type: string
+                userId:
+                  type: string
+      responses:
+        '200':
+          description: Path stored
+        '400':
+          description: Missing path
   /saveLessonPlan:
     post:
       summary: Update learning plan

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ function allow_cors(req, res, next) {
 }
 const memory_routes = require("./api/memory_routes");
 const github_routes = require("./api/github_routes");
+const mode_routes = require("./api/mode_routes");
 const { listMemoryFiles } = require("./logic/memory_operations");
 const versioning = require('./versioning');
 const { getMemoryModeSync } = require('./utils/memory_mode');
@@ -47,6 +48,7 @@ app.get('/ai-plugin.json', (_req, res) => {
 app.use(bodyParser.json());
 app.use(memory_routes);
 app.use(github_routes);
+app.use(mode_routes);
 
 app.post('/switch_memory_repo', async (req, res) => {
   const { type, path, userId } = req.body;

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -95,6 +95,26 @@ paths:
           description: Mode stored
         '400':
           description: Invalid mode
+  /local-path:
+    post:
+      summary: Set local storage path
+      operationId: setLocalPath
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                path:
+                  type: string
+                userId:
+                  type: string
+      responses:
+        '200':
+          description: Path stored
+        '400':
+          description: Missing path
   /saveLessonPlan:
     post:
       summary: Update learning plan

--- a/openapi_template.yaml
+++ b/openapi_template.yaml
@@ -95,6 +95,26 @@ paths:
           description: Mode stored
         '400':
           description: Invalid mode
+  /local-path:
+    post:
+      summary: Set local storage path
+      operationId: setLocalPath
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                path:
+                  type: string
+                userId:
+                  type: string
+      responses:
+        '200':
+          description: Path stored
+        '400':
+          description: Missing path
   /saveLessonPlan:
     post:
       summary: Update learning plan

--- a/src/memory_mode.js
+++ b/src/memory_mode.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const fsp = fs.promises;
 const path = require('path');
+const userMode = require('../utils/memory_mode');
 
 const cfgDir = path.join(__dirname, '..', 'config', '.sofia');
 const cfgPath = path.join(cfgDir, 'config.json');
@@ -47,12 +48,18 @@ function setMemoryModeSync(mode = 'github') {
   const cfg = loadConfigSync();
   cfg.memory_mode = (mode || 'github').toLowerCase();
   saveConfigSync(cfg);
+  try {
+    userMode.setMemoryModeSync('default', cfg.memory_mode);
+  } catch {}
 }
 
 async function setMemoryMode(mode = 'github') {
   const cfg = await loadConfig();
   cfg.memory_mode = (mode || 'github').toLowerCase();
   await saveConfig(cfg);
+  try {
+    await userMode.setMemoryMode('default', cfg.memory_mode);
+  } catch {}
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- register memory mode routes in server
- propagate global memory mode to user config
- add `/local-path` endpoint for specifying local memory directory
- document new route in all OpenAPI specs

## Testing
- `npm test` *(fails: AssertionError in `memory_dynamic_index_update.test.js`)*

------
https://chatgpt.com/codex/tasks/task_e_6867f828340c832389c096817b25a2ab