### PR TITLE
feat: add draft generator

### DIFF
--- a/src/generator/IterativeResponseGenerator.js
+++ b/src/generator/IterativeResponseGenerator.js
@@ -1,4 +1,4 @@
-const DraftGenerator = require('./DraftGenerator');
+const DraftGenerator = require('./draft/DraftGenerator');
 const GapAnalyzer = require('./GapAnalyzer');
 const DeepSearcher = require('./DeepSearcher');
 const ResponseEnhancer = require('./ResponseEnhancer');

--- a/src/generator/draft/DraftGenerator.js
+++ b/src/generator/draft/DraftGenerator.js
@@ -1,0 +1,38 @@
+class DraftGenerator {
+  /**
+   * Quickly generate a rough draft response.
+   * Only uses data from the provided hot cache to keep runtime low.
+   *
+   * @param {string} query - user query
+   * @param {Object} [context] - optional context with hotCache array
+   * @returns {Promise<{text: string, gaps: string[], confidence: number}>}
+   */
+  async generate(query, context = {}) {
+    const start = Date.now();
+    const hotCache = Array.isArray(context.hotCache) ? context.hotCache : [];
+
+    let text = `Draft response for: ${query}\n`;
+    const gaps = [];
+
+    if (hotCache.length > 0) {
+      // Use only a slice of the cache to avoid long processing times
+      text += hotCache.slice(0, 3).join(' ');
+    } else {
+      const marker = '[[GAP]]';
+      text += marker;
+      gaps.push(marker);
+    }
+
+    const confidence = 0.3; // initial drafts are low confidence
+
+    // Ensure we finish well under 3 seconds
+    const duration = Date.now() - start;
+    if (duration > 3000) {
+      throw new Error('Draft generation exceeded time limit');
+    }
+
+    return { text, gaps, confidence };
+  }
+}
+
+module.exports = DraftGenerator;

--- a/tests/draft_generator.test.js
+++ b/tests/draft_generator.test.js
@@ -1,0 +1,15 @@
+const assert = require('assert');
+const DraftGenerator = require('../src/generator/draft/DraftGenerator');
+
+(async function run() {
+  const generator = new DraftGenerator();
+  const start = Date.now();
+  const result = await generator.generate('Explain AI');
+  const duration = Date.now() - start;
+
+  assert(duration < 3000, 'generation should be fast');
+  assert(typeof result.text === 'string' && result.text.includes('[[GAP]]'), 'text includes gap marker');
+  assert(Array.isArray(result.gaps) && result.gaps.length > 0, 'gaps array present');
+  assert(result.confidence >= 0 && result.confidence <= 1, 'confidence within range');
+  console.log('draft generator test passed');
+})();


### PR DESCRIPTION
## Summary
- add DraftGenerator for fast draft responses using hot cache
- wire IterativeResponseGenerator to new draft module
- test draft generator for gap markers and confidence output

## Testing
- `node tests/draft_generator.test.js`
- `npm test` *(fails: memory_dynamic_index_update.test.js assertion)*

------
https://chatgpt.com/codex/tasks/task_e_6894e180f2dc832382220ab910c5e710