### PR TITLE
Add gap analyzer with heuristic detection

### DIFF
--- a/src/generator/IterativeResponseGenerator.js
+++ b/src/generator/IterativeResponseGenerator.js
@@ -1,5 +1,5 @@
 const DraftGenerator = require('./draft/DraftGenerator');
-const GapAnalyzer = require('./GapAnalyzer');
+const GapAnalyzer = require('./analysis/GapAnalyzer');
 const DeepSearcher = require('./DeepSearcher');
 const ResponseEnhancer = require('./ResponseEnhancer');
 const IterationController = require('./IterationController');

--- a/src/generator/analysis/GapAnalyzer.js
+++ b/src/generator/analysis/GapAnalyzer.js
@@ -1,0 +1,64 @@
+class GapAnalyzer {
+  constructor(opts = {}) {
+    this.confidenceThreshold = opts.confidenceThreshold || 0.75;
+    this.uncertaintyRules = opts.uncertaintyRules || [
+      { keyword: 'maybe', impact: 0.5, priority: 2 },
+      { keyword: 'perhaps', impact: 0.5, priority: 2 },
+      { keyword: 'might', impact: 0.3, priority: 1 },
+      { keyword: 'possibly', impact: 0.3, priority: 1 },
+      { keyword: 'uncertain', impact: 0.7, priority: 3 },
+      { keyword: 'unknown', impact: 0.7, priority: 3 },
+      { keyword: 'not sure', impact: 0.7, priority: 3 }
+    ];
+    this.undefinedPattern = opts.undefinedPattern || /<[^>]+>|\bTBD\b|\?\?\?|\bTODO\b/g;
+    this.referenceRules = opts.referenceRules || [
+      { keyword: 'citation needed', priority: 3 },
+      { keyword: 'source?', priority: 2 },
+      { keyword: 'ref?', priority: 2 },
+      { keyword: 'according to', priority: 2 }
+    ];
+  }
+
+  analyze(draft = '') {
+    const uncertainties = [];
+    const undefinedTerms = [];
+    const missingReferences = [];
+
+    const sentences = draft.split(/(?<=[.!?])\s+/);
+    for (const sentence of sentences) {
+      if (!sentence.trim()) continue;
+      const lower = sentence.toLowerCase();
+
+      let confidence = 1;
+      let priority = 0;
+      for (const rule of this.uncertaintyRules) {
+        if (lower.includes(rule.keyword)) {
+          confidence -= rule.impact;
+          priority = Math.max(priority, rule.priority);
+        }
+      }
+      if (confidence < this.confidenceThreshold) {
+        uncertainties.push({ text: sentence.trim(), confidence, priority });
+      }
+
+      let match;
+      while ((match = this.undefinedPattern.exec(sentence)) !== null) {
+        undefinedTerms.push({ term: match[0], priority: 3 });
+      }
+      this.undefinedPattern.lastIndex = 0;
+
+      for (const rule of this.referenceRules) {
+        if (lower.includes(rule.keyword)) {
+          const hasCitation = /\[[^\]]+\]|https?:\/\//.test(sentence);
+          if (!hasCitation) {
+            missingReferences.push({ text: sentence.trim(), priority: rule.priority });
+          }
+        }
+      }
+    }
+
+    return { uncertainties, undefinedTerms, missingReferences };
+  }
+}
+
+module.exports = GapAnalyzer;

--- a/tests/gap_analyzer.test.js
+++ b/tests/gap_analyzer.test.js
@@ -1,0 +1,15 @@
+const assert = require('assert');
+const GapAnalyzer = require('../src/generator/analysis/GapAnalyzer');
+
+(async function run(){
+  const analyzer = new GapAnalyzer();
+  const draft = `The result is maybe correct.\nWe will finalize <FooBar> later.\nAccording to experts this method works.`;
+  const res = analyzer.analyze(draft);
+  assert(Array.isArray(res.uncertainties) && res.uncertainties.length === 1, 'detects uncertainties');
+  assert(res.uncertainties[0].priority > 0, 'uncertainty has priority');
+  assert(Array.isArray(res.undefinedTerms) && res.undefinedTerms.length === 1, 'detects undefined terms');
+  assert(res.undefinedTerms[0].term.includes('<FooBar>'), 'undefined term captured');
+  assert(Array.isArray(res.missingReferences) && res.missingReferences.length === 1, 'detects missing references');
+  assert(res.missingReferences[0].priority > 0, 'missing reference has priority');
+  console.log('gap analyzer test passed');
+})();


### PR DESCRIPTION
## Summary
- implement a GapAnalyzer for drafts with keyword spotting and confidence-based heuristics
- integrate new analyzer into IterativeResponseGenerator
- cover analyzer with unit tests

## Testing
- `node tests/gap_analyzer.test.js`
- `npm test` *(fails: memory_dynamic_index_update.test.js assertion error)*

------
https://chatgpt.com/codex/tasks/task_e_6894e54010ec83239cb7dd08e9ba40f5