### PR TITLE
feat: add deep searcher

### DIFF
--- a/src/generator/search/DeepSearcher.js
+++ b/src/generator/search/DeepSearcher.js
@@ -1,0 +1,83 @@
+class DeepSearcher {
+  constructor(opts = {}) {
+    this.hotCache = opts.hotCache || null;
+    this.warmStorage = opts.warmStorage || null;
+    this.coldStorage = opts.coldStorage || null;
+    this.externalSources = opts.externalSources || [];
+    this.timeout = opts.timeout || 1000; // default timeout in ms
+  }
+
+  async search(query) {
+    const results = new Map();
+
+    const addResults = items => {
+      if (!items) return;
+      for (const item of items) {
+        const key = this._key(item);
+        if (!results.has(key)) results.set(key, item);
+      }
+    };
+
+    // Hot cache first
+    if (this.hotCache && typeof this.hotCache.search === 'function') {
+      try {
+        const hot = await this._withTimeout(this.hotCache.search(query));
+        addResults(hot);
+      } catch (e) {
+        // ignore hot cache errors
+      }
+    }
+
+    // Warm and cold storage in parallel
+    const storagePromises = [];
+    if (this.warmStorage && typeof this.warmStorage.search === 'function') {
+      storagePromises.push(this._withTimeout(this.warmStorage.search(query)));
+    }
+    if (this.coldStorage && typeof this.coldStorage.search === 'function') {
+      storagePromises.push(this._withTimeout(this.coldStorage.search(query)));
+    }
+    const storageResults = await Promise.allSettled(storagePromises);
+    for (const r of storageResults) {
+      if (r.status === 'fulfilled') addResults(r.value);
+    }
+
+    // External sources last
+    if (Array.isArray(this.externalSources) && this.externalSources.length) {
+      const extPromises = this.externalSources
+        .filter(s => s && typeof s.search === 'function')
+        .map(s => this._withTimeout(s.search(query)));
+      const extResults = await Promise.allSettled(extPromises);
+      for (const r of extResults) {
+        if (r.status === 'fulfilled') addResults(r.value);
+      }
+    }
+
+    return Array.from(results.values());
+  }
+
+  _withTimeout(promise, ms = this.timeout) {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('Timeout')), ms);
+      Promise.resolve(promise).then(
+        value => {
+          clearTimeout(timer);
+          resolve(value);
+        },
+        err => {
+          clearTimeout(timer);
+          reject(err);
+        }
+      );
+    });
+  }
+
+  _key(item) {
+    if (item && typeof item === 'object') {
+      return item.id || JSON.stringify(item);
+    }
+    return item;
+  }
+}
+
+module.exports = DeepSearcher;
+

--- a/tests/deep_searcher.test.js
+++ b/tests/deep_searcher.test.js
@@ -1,0 +1,33 @@
+const assert = require('assert');
+const DeepSearcher = require('../src/generator/search/DeepSearcher');
+
+class MockSource {
+  constructor(results, delay = 0) {
+    this.results = results;
+    this.delay = delay;
+  }
+  async search() {
+    await new Promise(r => setTimeout(r, this.delay));
+    return this.results;
+  }
+}
+
+(async function run() {
+  // Tiered search and deduplication
+  const hot = new MockSource(['a', 'b']);
+  const warm = new MockSource(['b', 'c'], 20);
+  const cold = new MockSource(['c', 'd'], 20);
+  const ext = [new MockSource(['d', 'e'], 20)];
+  const searcher = new DeepSearcher({ hotCache: hot, warmStorage: warm, coldStorage: cold, externalSources: ext, timeout: 100 });
+  const res = await searcher.search('q');
+  assert.deepStrictEqual(res.sort(), ['a', 'b', 'c', 'd', 'e'].sort(), 'tiered search with dedup');
+
+  // Timeout control
+  const slow = new MockSource(['x'], 200);
+  const searcher2 = new DeepSearcher({ hotCache: hot, warmStorage: slow, timeout: 50 });
+  const res2 = await searcher2.search('q');
+  assert.deepStrictEqual(res2.sort(), ['a', 'b'].sort(), 'timeout excludes slow sources');
+
+  console.log('deep searcher test passed');
+})();
+


### PR DESCRIPTION
## Summary
- add DeepSearcher with tiered cache/storage/external search and timeouts
- test tiered search, deduplication, and timeout handling

## Testing
- `npm test` (fails: memory_dynamic_index_update.test.js: AssertionError)


------
https://chatgpt.com/codex/tasks/task_e_6894e91a630c8323bbdb1c190a5fa844