### PR TITLE
feat: add response enhancer

### DIFF
--- a/src/generator/enhancement/ResponseEnhancer.js
+++ b/src/generator/enhancement/ResponseEnhancer.js
@@ -1,0 +1,54 @@
+class ResponseEnhancer {
+  constructor() {
+    // keep a running log of every change applied
+    this.log = [];
+  }
+
+  /**
+   * Enhance a draft response using search results.
+   * Results are applied in priority order:
+   *   CRITICAL_CORRECTION > IMPORTANT_ADDITION > CONTEXT_ENRICHMENT.
+   * Each applied change is recorded in the changelog for later inspection.
+   *
+   * @param {string} draft - original draft text
+   * @param {Array<{directive: string, content: string}>} searchResults
+   * @returns {{text: string, changes: Array<{directive: string, content: string}>}}
+   */
+  enhance(draft = '', searchResults = []) {
+    const priorities = {
+      CRITICAL_CORRECTION: 3,
+      IMPORTANT_ADDITION: 2,
+      CONTEXT_ENRICHMENT: 1
+    };
+    const prefixes = {
+      CRITICAL_CORRECTION: 'Critical correction: ',
+      IMPORTANT_ADDITION: 'Important addition: ',
+      CONTEXT_ENRICHMENT: 'Context: '
+    };
+
+    const ordered = Array.isArray(searchResults)
+      ? [...searchResults].sort(
+          (a, b) => (priorities[b.directive] || 0) - (priorities[a.directive] || 0)
+        )
+      : [];
+
+    let text = draft;
+    const changes = [];
+
+    for (const r of ordered) {
+      if (!r || typeof r.content !== 'string') continue;
+      const directive = r.directive;
+      if (!prefixes[directive]) continue;
+      if (text && !text.endsWith('\n')) text += '\n';
+      const addition = prefixes[directive] + r.content;
+      text += addition;
+      const change = { directive, content: r.content };
+      changes.push(change);
+      this.log.push(change);
+    }
+
+    return { text, changes };
+  }
+}
+
+module.exports = ResponseEnhancer;

--- a/tests/response_enhancer.test.js
+++ b/tests/response_enhancer.test.js
@@ -1,0 +1,57 @@
+const assert = require('assert');
+const ResponseEnhancer = require('../src/generator/enhancement/ResponseEnhancer');
+
+(async function run() {
+  const enhancer = new ResponseEnhancer();
+  const draft = 'Base draft';
+  const results = [
+    { directive: 'CONTEXT_ENRICHMENT', content: 'extra context' },
+    { directive: 'CRITICAL_CORRECTION', content: 'fix critical error' },
+    { directive: 'IMPORTANT_ADDITION', content: 'add important fact' }
+  ];
+
+  const out = enhancer.enhance(draft, results);
+
+  assert.strictEqual(
+    out.text,
+    'Base draft\nCritical correction: fix critical error\nImportant addition: add important fact\nContext: extra context',
+    'enhanced text should apply directives in priority order'
+  );
+
+  assert.deepStrictEqual(
+    out.changes,
+    [
+      { directive: 'CRITICAL_CORRECTION', content: 'fix critical error' },
+      { directive: 'IMPORTANT_ADDITION', content: 'add important fact' },
+      { directive: 'CONTEXT_ENRICHMENT', content: 'extra context' }
+    ],
+    'changes should reflect applied directives'
+  );
+
+  // changelog accumulates
+  assert.deepStrictEqual(enhancer.log, out.changes, 'log should record changes');
+
+  // second enhancement to ensure history persists and output resets
+  const out2 = enhancer.enhance('Next draft', [
+    { directive: 'IMPORTANT_ADDITION', content: 'second addition' }
+  ]);
+
+  assert.strictEqual(
+    out2.text,
+    'Next draft\nImportant addition: second addition',
+    'subsequent enhancements should work'
+  );
+
+  assert.deepStrictEqual(
+    enhancer.log,
+    [
+      { directive: 'CRITICAL_CORRECTION', content: 'fix critical error' },
+      { directive: 'IMPORTANT_ADDITION', content: 'add important fact' },
+      { directive: 'CONTEXT_ENRICHMENT', content: 'extra context' },
+      { directive: 'IMPORTANT_ADDITION', content: 'second addition' }
+    ],
+    'log should maintain history across enhancements'
+  );
+
+  console.log('response enhancer test passed');
+})();


### PR DESCRIPTION
## Summary
- add ResponseEnhancer to prioritize and apply search result directives
- log applied changes for later inspection
- cover enhancement logic with unit tests

## Testing
- `node tests/response_enhancer.test.js`
- `npm test` *(fails: memory_dynamic_index_update.test.js assertion error)*

------
https://chatgpt.com/codex/tasks/task_e_6894f12ea5448323b269f92e080c2b6b