### PR TITLE
feat: add source manager with reliability and dedup

### DIFF
--- a/src/sources/SourceManager.js
+++ b/src/sources/SourceManager.js
@@ -1,0 +1,61 @@
+const SOURCE_RELIABILITY = {
+  HIGH: 3,
+  MEDIUM: 2,
+  LOW: 1,
+  UNKNOWN: 0
+};
+
+function calculateSourceLimit({ baseLimit = 10, reliability = 'LOW' } = {}) {
+  const relKey = reliability.toUpperCase();
+  const weight = SOURCE_RELIABILITY[relKey] ?? SOURCE_RELIABILITY.UNKNOWN;
+  const total = SOURCE_RELIABILITY.HIGH + SOURCE_RELIABILITY.MEDIUM + SOURCE_RELIABILITY.LOW;
+  const limit = Math.max(1, Math.ceil((baseLimit * weight) / total));
+  return limit;
+}
+
+class SourceManager {
+  constructor() {
+    this.sources = [];
+  }
+
+  addSource(id, reliability, entries = []) {
+    this.sources.push({ id, reliability, entries });
+  }
+
+  merge() {
+    const relWeight = rel => SOURCE_RELIABILITY[rel?.toUpperCase()] || 0;
+    const sorted = [...this.sources].sort((a, b) => relWeight(b.reliability) - relWeight(a.reliability));
+    const seen = new Set();
+    const totals = new Map();
+    const uniques = new Map();
+    const result = [];
+
+    for (const src of sorted) {
+      totals.set(src.id, src.entries.length);
+      uniques.set(src.id, 0);
+      for (const entry of src.entries) {
+        const content = entry && entry.content;
+        if (!content) continue;
+        if (!seen.has(content)) {
+          seen.add(content);
+          result.push({ ...entry, source: src.id });
+          uniques.set(src.id, uniques.get(src.id) + 1);
+        }
+      }
+    }
+
+    const final = result.filter(e => {
+      const u = uniques.get(e.source) || 0;
+      const t = totals.get(e.source) || 1;
+      return u / t >= 0.3;
+    });
+
+    return final;
+  }
+}
+
+module.exports = {
+  SOURCE_RELIABILITY,
+  calculateSourceLimit,
+  SourceManager
+};

--- a/tests/source_manager.test.js
+++ b/tests/source_manager.test.js
@@ -1,0 +1,54 @@
+process.env.NO_GIT = "true";
+const assert = require('assert');
+const { SourceManager, SOURCE_RELIABILITY, calculateSourceLimit } = require('../src/sources/SourceManager');
+
+(function reliabilityHierarchy() {
+  assert.ok(SOURCE_RELIABILITY.HIGH > SOURCE_RELIABILITY.MEDIUM);
+  assert.ok(SOURCE_RELIABILITY.MEDIUM > SOURCE_RELIABILITY.LOW);
+})();
+
+(function limitCalculation() {
+  const high = calculateSourceLimit({ baseLimit: 12, reliability: 'high' });
+  const low = calculateSourceLimit({ baseLimit: 12, reliability: 'low' });
+  assert.ok(high > low, 'high reliability should have higher limit');
+})();
+
+(function dedupAndPriority() {
+  const mgr = new SourceManager();
+  mgr.addSource('s1', 'high', [
+    { content: 'alpha' },
+    { content: 'beta' }
+  ]);
+  mgr.addSource('s2', 'low', [
+    { content: 'alpha' },
+    { content: 'gamma' },
+    { content: 'delta' }
+  ]);
+  const merged = mgr.merge();
+  const alphaEntries = merged.filter(e => e.content === 'alpha');
+  assert.strictEqual(alphaEntries.length, 1, 'duplicate kept once');
+  assert.strictEqual(alphaEntries[0].source, 's1', 'high reliability source kept duplicate');
+  const sources = new Set(merged.map(e => e.source));
+  assert.ok(sources.has('s1')); // high source kept
+  assert.ok(sources.has('s2')); // low source still has >30% unique
+})();
+
+(function uniqueThreshold() {
+  const mgr = new SourceManager();
+  mgr.addSource('main', 'high', [
+    { content: 'x' },
+    { content: 'y' },
+    { content: 'z' }
+  ]);
+  mgr.addSource('spam', 'low', [
+    { content: 'x' },
+    { content: 'y' },
+    { content: 'z' },
+    { content: 'x' }
+  ]);
+  const merged = mgr.merge();
+  const sources = new Set(merged.map(e => e.source));
+  assert.ok(!sources.has('spam'), 'source with <30% unique content removed');
+})();
+
+console.log('source_manager tests passed');


### PR DESCRIPTION
## Summary
- implement source reliability hierarchy and limit calculation
- deduplicate sources enforcing ≥30% unique content and preferring high reliability
- add unit tests for SourceManager

## Testing
- `node tests/source_manager.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68950275ac808323a8cc277fc54aa770