### PR TITLE
Add model installation scripts with mirror fallback

### DIFF
--- a/scripts/install_model.ps1
+++ b/scripts/install_model.ps1
@@ -1,0 +1,40 @@
+param(
+    [Parameter(Mandatory = $true)][string]$ModelPath,
+    [Parameter(Mandatory = $true)][string]$OutputDir
+)
+
+$ErrorActionPreference = 'Stop'
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+$repo = Split-Path $ModelPath
+$file = Split-Path $ModelPath -Leaf
+
+$primaryUrl = "https://huggingface.co/$repo/resolve/main/$file"
+$mirrorUrl = "https://huggingface.co/bartowski/$repo/resolve/main/$file"
+
+if (-not (Test-Path -Path $OutputDir)) {
+    New-Item -ItemType Directory -Path $OutputDir | Out-Null
+}
+
+$outputFile = Join-Path $OutputDir $file
+
+function Download-Model {
+    param([string]$Url)
+    try {
+        Invoke-WebRequest -Uri $Url -OutFile $outputFile -UseBasicParsing
+        Write-Host "Saved model to $outputFile"
+        return $true
+    } catch {
+        Write-Host "Download failed from $Url: $($_.Exception.Message)"
+        return $false
+    }
+}
+
+if (Download-Model $primaryUrl) {
+    exit 0
+} elseif (Download-Model $mirrorUrl) {
+    exit 0
+} else {
+    Write-Error "Failed to download $file from primary and mirror URLs."
+    exit 1
+}

--- a/scripts/install_model.sh
+++ b/scripts/install_model.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <model_path> <output_dir>" >&2
+  exit 1
+fi
+
+MODEL_PATH="$1"
+OUTPUT_DIR="$2"
+
+REPO="$(dirname "$MODEL_PATH")"
+FILE="$(basename "$MODEL_PATH")"
+
+PRIMARY_URL="https://huggingface.co/${REPO}/resolve/main/${FILE}"
+MIRROR_URL="https://huggingface.co/bartowski/${REPO}/resolve/main/${FILE}"
+
+mkdir -p "$OUTPUT_DIR"
+OUT_FILE="${OUTPUT_DIR}/${FILE}"
+
+_download() {
+  local url="$1"
+  echo "Downloading ${FILE} from ${url}"
+  if curl -fL "$url" -o "$OUT_FILE"; then
+    echo "Saved model to ${OUT_FILE}"
+    return 0
+  fi
+  return 1
+}
+
+if _download "$PRIMARY_URL"; then
+  exit 0
+elif _download "$MIRROR_URL"; then
+  exit 0
+else
+  echo "Failed to download ${FILE} from primary and mirror URLs." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add PowerShell script to download Hugging Face models with mirror fallback
- add Unix shell script using curl to download models with mirror fallback

## Testing
- `npm test` *(fails: AssertionError [ERR_ASSERTION])*

------
https://chatgpt.com/codex/tasks/task_e_6895b601d51c83238fdce51503b7cf67