### PR TITLE
feat: add session summarizer

### DIFF
--- a/logic/index_manager.js
+++ b/logic/index_manager.js
@@ -324,7 +324,7 @@ async function moveFileAndUpdateIndex(oldPath, newPath) {
 
 async function saveIndex(token, repo, userId) {
   if (!indexData) await loadIndex();
-  const old_list = index_tree.listAllEntries();
+  const old_list = loadIndexSync();
   const old_paths = old_list.map(e => e.path);
   const manual_set = new Set(
     old_list.filter(e => e.source === 'manual').map(e => e.path)

--- a/memory/index.json
+++ b/memory/index.json
@@ -12,6 +12,10 @@
     {
       "category": "drafts",
       "path": "drafts/index.json"
+    },
+    {
+      "category": "summaries",
+      "path": "summaries/index.json"
     }
   ]
 }

--- a/memory/summaries/index.json
+++ b/memory/summaries/index.json
@@ -1,0 +1,5 @@
+{
+  "type": "index-branch",
+  "category": "summaries",
+  "files": []
+}

--- a/src/generator/summarization/SessionSummarizer.js
+++ b/src/generator/summarization/SessionSummarizer.js
@@ -1,0 +1,120 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * SessionSummarizer provides simple summarization and storage utilities
+ * for question/answer pairs. Summaries are stored under memory/summaries
+ * along with references to full question and answer text files.
+ */
+class SessionSummarizer {
+  constructor(opts = {}) {
+    this.memoryRoot = opts.memoryRoot || path.join(__dirname, '..', '..', '..', 'memory');
+    this.summaryDir = path.join(this.memoryRoot, 'summaries');
+    this.indexPath = path.join(this.summaryDir, 'index.json');
+  }
+
+  /**
+   * Create a concise summary string for a question/answer pair.
+   * @param {string} question
+   * @param {string} answer
+   * @returns {string}
+   */
+  summarizePair(question = '', answer = '') {
+    const norm = str => String(str).replace(/\s+/g, ' ').trim();
+    const q = norm(question).slice(0, 60);
+    const a = norm(answer).slice(0, 100);
+    const qEllipsis = q.length < norm(question).length ? '...' : '';
+    const aEllipsis = a.length < norm(answer).length ? '...' : '';
+    return `Q: ${q}${qEllipsis} A: ${a}${aEllipsis}`.trim();
+  }
+
+  /**
+   * Persist summary and full texts to memory/summaries.
+   * Stores full question and answer in separate files and writes
+   * an index entry with absolute paths to these sources.
+   *
+   * @param {string} sessionId
+   * @param {string} summary
+   * @param {string} fullQuestion
+   * @param {string} fullAnswer
+   * @returns {{summaryPath: string, questionPath: string, answerPath: string}}
+   */
+  storeSummary(sessionId, summary, fullQuestion = '', fullAnswer = '') {
+    if (!sessionId) throw new Error('sessionId required');
+    fs.mkdirSync(this.summaryDir, { recursive: true });
+
+    const questionPath = path.resolve(this.summaryDir, `${sessionId}_question.md`);
+    const answerPath = path.resolve(this.summaryDir, `${sessionId}_answer.md`);
+    fs.writeFileSync(questionPath, fullQuestion, 'utf-8');
+    fs.writeFileSync(answerPath, fullAnswer, 'utf-8');
+
+    const summaryPath = path.resolve(this.summaryDir, `${sessionId}.json`);
+    const data = {
+      sessionId,
+      summary,
+      questionPath,
+      answerPath,
+    };
+    fs.writeFileSync(summaryPath, JSON.stringify(data, null, 2));
+
+    // update index
+    let indexData;
+    if (fs.existsSync(this.indexPath)) {
+      try {
+        indexData = JSON.parse(fs.readFileSync(this.indexPath, 'utf-8'));
+      } catch {
+        indexData = null;
+      }
+    }
+    if (!indexData || typeof indexData !== 'object') {
+      indexData = { type: 'index-branch', category: 'summaries', files: [] };
+    }
+    if (!Array.isArray(indexData.files)) indexData.files = [];
+    const relSummary = path.relative(this.memoryRoot, summaryPath).replace(/\\/g, '/');
+    const entry = { title: summary, file: relSummary };
+    const existing = indexData.files.findIndex(f => f.file === relSummary);
+    if (existing >= 0) {
+      indexData.files[existing] = entry;
+    } else {
+      indexData.files.push(entry);
+    }
+    fs.writeFileSync(this.indexPath, JSON.stringify(indexData, null, 2));
+
+    return { summaryPath, questionPath, answerPath };
+  }
+
+  /**
+   * Retrieve stored summary by session id.
+   * @param {string} sessionId
+   * @returns {string|null}
+   */
+  getSummary(sessionId) {
+    if (!sessionId) return null;
+    const summaryPath = path.join(this.summaryDir, `${sessionId}.json`);
+    if (!fs.existsSync(summaryPath)) return null;
+    try {
+      const data = JSON.parse(fs.readFileSync(summaryPath, 'utf-8'));
+      return data.summary || null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Get full text content by reference path.
+   * @param {string} ref - absolute or relative path to stored file
+   * @returns {string|null}
+   */
+  getFullText(ref) {
+    if (!ref) return null;
+    let p = ref;
+    if (!path.isAbsolute(p)) {
+      p = path.resolve(this.memoryRoot, ref);
+    }
+    if (!fs.existsSync(p)) return null;
+    return fs.readFileSync(p, 'utf-8');
+  }
+}
+
+module.exports = SessionSummarizer;
+

--- a/tools/index_tree.js
+++ b/tools/index_tree.js
@@ -18,6 +18,17 @@ function loadRoot() {
   }
   const raw = fs.readFileSync(rootIndexPath, 'utf-8');
   const data = JSON.parse(raw);
+  // ensure summaries branch exists if summaries index is present
+  if (Array.isArray(data.branches)) {
+    const hasSummaries = data.branches.some(b => b.category === 'summaries');
+    if (!hasSummaries) {
+      const summariesRel = path.join('summaries', 'index.json');
+      const summariesPath = path.join(__dirname, '..', 'memory', summariesRel);
+      if (fs.existsSync(summariesPath)) {
+        data.branches.push({ category: 'summaries', path: summariesRel });
+      }
+    }
+  }
   if (!validateRootIndex(data)) {
     console.error('[index_tree] root index schema invalid');
     throw new Error('invalid root index');


### PR DESCRIPTION
## Summary
- implement `SessionSummarizer` to generate and store Q/A summaries under `memory/summaries`
- index summaries branch by default in `index_tree`
- adjust index saving logic to use filtered snapshot

## Testing
- `npm test` *(fails: File not found: memory/lessons/04_example.md)*

------
https://chatgpt.com/codex/tasks/task_e_6895e40339608323b96d0b8070910401