### PR TITLE
feat: enrich iterative responses with reference-based context

### DIFF
--- a/src/generator/IterativeResponseGenerator.js
+++ b/src/generator/IterativeResponseGenerator.js
@@ -1,8 +1,9 @@
 const DraftGenerator = require('./draft/DraftGenerator');
 const GapAnalyzer = require('./analysis/GapAnalyzer');
-const DeepSearcher = require('./DeepSearcher');
-const ResponseEnhancer = require('./ResponseEnhancer');
+const DeepSearcher = require('./search/DeepSearcher');
+const ResponseEnhancer = require('./enhancement/ResponseEnhancer');
 const IterationController = require('./IterationController');
+const SessionSummarizer = require('./summarization/SessionSummarizer');
 
 /**
  * Coordinates iterative response generation. Each iteration:
@@ -29,6 +30,8 @@ class IterativeResponseGenerator {
       opts.responseEnhancer || new ResponseEnhancer();
     this.iterationController =
       opts.iterationController || new IterationController();
+    this.sessionSummarizer =
+      opts.sessionSummarizer || new SessionSummarizer();
   }
 
   /**
@@ -38,19 +41,38 @@ class IterativeResponseGenerator {
    * @returns {Promise<string>} Final response text
    */
   async generateResponse(query, context = {}) {
+    context.hotCache = Array.isArray(context.hotCache) ? context.hotCache : [];
+    context.usedFullTexts = Array.isArray(context.usedFullTexts)
+      ? context.usedFullTexts
+      : [];
+
+    if (context.sessionId) {
+      const summary = this.sessionSummarizer.getSummary(context.sessionId);
+      if (summary) context.hotCache.push(summary);
+    }
+
     let response = await this.draftGenerator.generate(query, context);
     let iteration = 0;
 
     while (this.iterationController.shouldContinue(iteration, response, context)) {
-      const gaps = await this.gapAnalyzer.analyze(response, query, context);
-      if (!gaps || gaps.length === 0) break;
-      const findings = await this.deepSearcher.search(gaps, query, context);
-      response = await this.responseEnhancer.enhance(
+      const analysis = await this.gapAnalyzer.analyze(response, query, context);
+      const refIds = analysis && analysis.referenceIds ? analysis.referenceIds : [];
+      if (
+        !analysis ||
+        (!analysis.uncertainties.length &&
+          !analysis.undefinedTerms.length &&
+          !analysis.missingReferences.length &&
+          refIds.length === 0)
+      )
+        break;
+
+      const findings = await this.deepSearcher.search(query, refIds, context);
+      const enhanced = await this.responseEnhancer.enhance(
         response,
         findings,
-        query,
         context
       );
+      response = enhanced.text || enhanced;
       iteration += 1;
     }
 

--- a/src/generator/analysis/GapAnalyzer.js
+++ b/src/generator/analysis/GapAnalyzer.js
@@ -17,12 +17,14 @@ class GapAnalyzer {
       { keyword: 'ref?', priority: 2 },
       { keyword: 'according to', priority: 2 }
     ];
+    this.refMarkerPattern = opts.refMarkerPattern || /\[\[REF:([^\]]+)\]\]/g;
   }
 
   analyze(draft = '') {
     const uncertainties = [];
     const undefinedTerms = [];
     const missingReferences = [];
+    const referenceIds = [];
 
     const sentences = draft.split(/(?<=[.!?])\s+/);
     for (const sentence of sentences) {
@@ -57,7 +59,13 @@ class GapAnalyzer {
       }
     }
 
-    return { uncertainties, undefinedTerms, missingReferences };
+    let refMatch;
+    while ((refMatch = this.refMarkerPattern.exec(draft)) !== null) {
+      referenceIds.push(refMatch[1]);
+    }
+    this.refMarkerPattern.lastIndex = 0;
+
+    return { uncertainties, undefinedTerms, missingReferences, referenceIds };
   }
 }
 

--- a/src/generator/enhancement/ResponseEnhancer.js
+++ b/src/generator/enhancement/ResponseEnhancer.js
@@ -2,6 +2,7 @@ class ResponseEnhancer {
   constructor() {
     // keep a running log of every change applied
     this.log = [];
+    this.fullReferenceLog = [];
   }
 
   /**
@@ -14,7 +15,7 @@ class ResponseEnhancer {
    * @param {Array<{directive: string, content: string}>} searchResults
    * @returns {{text: string, changes: Array<{directive: string, content: string}>}}
    */
-  enhance(draft = '', searchResults = []) {
+  enhance(draft = '', searchResults = [], context = {}) {
     const priorities = {
       CRITICAL_CORRECTION: 3,
       IMPORTANT_ADDITION: 2,
@@ -31,6 +32,18 @@ class ResponseEnhancer {
           (a, b) => (priorities[b.directive] || 0) - (priorities[a.directive] || 0)
         )
       : [];
+
+    if (
+      context &&
+      Array.isArray(context.usedFullTexts) &&
+      context.usedFullTexts.length
+    ) {
+      this.fullReferenceLog.push(...context.usedFullTexts);
+      console.log(
+        '[ResponseEnhancer] full references used:',
+        context.usedFullTexts.join(', ')
+      );
+    }
 
     let text = draft;
     const changes = [];


### PR DESCRIPTION
## Summary
- load session summaries into hot cache before drafting
- detect `[[REF:...]]` markers and retrieve full text during deep searches
- log when full reference answers influence response enhancement

## Testing
- `npm test` *(fails: File not found: memory/lessons/04_example.md)*

------
https://chatgpt.com/codex/tasks/task_e_6895ea489f1483239c3daa2039b60e07