### PR TITLE
Add coverage for session summarizer and iterative responses

### DIFF
--- a/tests/iterative_generation_with_summary.test.js
+++ b/tests/iterative_generation_with_summary.test.js
@@ -1,0 +1,61 @@
+process.env.NO_GIT = "true";
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const SessionSummarizer = require('../src/generator/summarization/SessionSummarizer');
+const IterativeResponseGenerator = require('../src/generator/IterativeResponseGenerator');
+const GapAnalyzer = require('../src/generator/analysis/GapAnalyzer');
+const DeepSearcher = require('../src/generator/search/DeepSearcher');
+
+class StubDraftGenerator {
+  async generate(query, context) {
+    return `Stub draft [[REF:${context.ref}]]`;
+  }
+}
+
+class StubEnhancer {
+  enhance(draft, results) {
+    const additions = Array.isArray(results)
+      ? results.map(r => r.content).join('\n')
+      : '';
+    return { text: draft + (additions ? '\n' + additions : ''), changes: [] };
+  }
+}
+
+class StubController {
+  shouldContinue(iteration) {
+    return iteration < 1;
+  }
+}
+
+(async function run() {
+  const tempDir = path.join(__dirname, 'tmp_iterative');
+  if (fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true, force: true });
+  const summarizer = new SessionSummarizer({ memoryRoot: tempDir });
+
+  const question = 'What is the meaning of life?';
+  const answer = '42 is often cited as the answer to life, the universe, and everything.';
+  const summary = summarizer.summarizePair(question, answer);
+  const sessionId = 'iter-session';
+  const { answerPath } = summarizer.storeSummary(sessionId, summary, question, answer);
+
+  const generator = new IterativeResponseGenerator({
+    draftGenerator: new StubDraftGenerator(),
+    gapAnalyzer: new GapAnalyzer(),
+    deepSearcher: new DeepSearcher({ sessionSummarizer: summarizer }),
+    responseEnhancer: new StubEnhancer(),
+    iterationController: new StubController(),
+    sessionSummarizer: summarizer,
+  });
+
+  const context = { sessionId, ref: answerPath };
+  const final = await generator.generateResponse('dummy', context);
+
+  assert.ok(context.hotCache.includes(summary), 'summary loaded into hot cache');
+  assert.ok(context.hotCache.includes(answer), 'full answer loaded into hot cache');
+  assert.ok(context.usedFullTexts.includes(answerPath), 'full text reference recorded');
+  assert.ok(final.includes(answer), 'final response includes full answer');
+
+  fs.rmSync(tempDir, { recursive: true, force: true });
+  console.log('iterative generation with summary test passed');
+})();

--- a/tests/runAll.js
+++ b/tests/runAll.js
@@ -4,10 +4,13 @@ const { execFileSync } = require('child_process');
 
 const testDir = __dirname;
 
-fs.readdirSync(testDir)
+const files = fs
+  .readdirSync(testDir)
   .filter(f => f.endsWith('.test.js'))
-  .forEach(file => {
-    const p = path.join(testDir, file);
-    console.log(`Running ${file}`);
-    execFileSync('node', [p], { stdio: 'inherit' });
-  });
+  .sort();
+
+files.forEach(file => {
+  const p = path.join(testDir, file);
+  console.log(`Running ${file}`);
+  execFileSync('node', [p], { stdio: 'inherit' });
+});

--- a/tests/session_summarizer.test.js
+++ b/tests/session_summarizer.test.js
@@ -1,0 +1,38 @@
+process.env.NO_GIT = "true";
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const SessionSummarizer = require('../src/generator/summarization/SessionSummarizer');
+
+(function run() {
+  const tempDir = path.join(__dirname, 'tmp_summarizer');
+  if (fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true, force: true });
+  const summarizer = new SessionSummarizer({ memoryRoot: tempDir });
+
+  const question = 'This is a very long question that should be trimmed when creating a summary.';
+  const answer = 'This is an even longer answer that contains lots of details and also should be trimmed in the summary representation.';
+
+  const summary = summarizer.summarizePair(question, answer);
+  const sessionId = 'session-test';
+  const { questionPath, answerPath, summaryPath } = summarizer.storeSummary(
+    sessionId,
+    summary,
+    question,
+    answer
+  );
+
+  assert.ok(fs.existsSync(summaryPath), 'summary file should be created');
+  assert.ok(fs.existsSync(questionPath), 'question file should be created');
+  assert.ok(fs.existsSync(answerPath), 'answer file should be created');
+
+  const storedSummary = summarizer.getSummary(sessionId);
+  assert.strictEqual(storedSummary, summary, 'summary should be retrievable');
+
+  const restoredQuestion = summarizer.getFullText(questionPath);
+  const restoredAnswer = summarizer.getFullText(answerPath);
+  assert.strictEqual(restoredQuestion, question, 'question restored correctly');
+  assert.strictEqual(restoredAnswer, answer, 'answer restored correctly');
+
+  fs.rmSync(tempDir, { recursive: true, force: true });
+  console.log('session summarizer test passed');
+})();


### PR DESCRIPTION
## Summary
- add tests verifying session summary storage and retrieval
- add iterative generation test ensuring full text is loaded from references
- sort test runner for deterministic execution

## Testing
- `node tests/runAll.js` *(fails: File not found in memory_functions.test.js)*
- `node tests/session_summarizer.test.js`
- `node tests/iterative_generation_with_summary.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6895f5a649988323af2494847be20477