### PR TITLE
refactor iteration controller state handling

### DIFF
--- a/src/generator/analysis/GapAnalyzer.js
+++ b/src/generator/analysis/GapAnalyzer.js
@@ -65,7 +65,22 @@ class GapAnalyzer {
     }
     this.refMarkerPattern.lastIndex = 0;
 
-    return { uncertainties, undefinedTerms, missingReferences, referenceIds };
+    const gaps = [...uncertainties, ...undefinedTerms, ...missingReferences];
+    const uncertaintyConfs = uncertainties.map(u => u.confidence);
+    let confidence = uncertaintyConfs.length
+      ? Math.min(...uncertaintyConfs)
+      : 1;
+    confidence -= 0.1 * (undefinedTerms.length + missingReferences.length);
+    confidence = Math.max(0, Math.min(1, confidence));
+
+    return {
+      uncertainties,
+      undefinedTerms,
+      missingReferences,
+      referenceIds,
+      gaps,
+      confidence,
+    };
   }
 }
 

--- a/tests/gap_analyzer.test.js
+++ b/tests/gap_analyzer.test.js
@@ -11,5 +11,7 @@ const GapAnalyzer = require('../src/generator/analysis/GapAnalyzer');
   assert(res.undefinedTerms[0].term.includes('<FooBar>'), 'undefined term captured');
   assert(Array.isArray(res.missingReferences) && res.missingReferences.length === 1, 'detects missing references');
   assert(res.missingReferences[0].priority > 0, 'missing reference has priority');
+  assert(Array.isArray(res.gaps) && res.gaps.length === 3, 'aggregates gaps');
+  assert(res.confidence >= 0 && res.confidence <= 1, 'returns confidence');
   console.log('gap analyzer test passed');
 })();

--- a/tests/iteration_controller.test.js
+++ b/tests/iteration_controller.test.js
@@ -15,6 +15,12 @@ class MockOptimizer {
 
   const start = Date.now();
 
+  // Backwards compatibility with old signature
+  assert(
+    controller.shouldContinue(0, 'resp', {}),
+    'supports old signature'
+  );
+
   // Should continue when gaps remain and under limits
   assert(
     controller.shouldContinue({

--- a/tests/iterative_generation_with_summary.test.js
+++ b/tests/iterative_generation_with_summary.test.js
@@ -9,7 +9,11 @@ const DeepSearcher = require('../src/generator/search/DeepSearcher');
 
 class StubDraftGenerator {
   async generate(query, context) {
-    return `Stub draft [[REF:${context.ref}]]`;
+    return {
+      text: `Stub draft [[REF:${context.ref}]]`,
+      gaps: ['init'],
+      confidence: 0.5,
+    };
   }
 }
 
@@ -23,8 +27,9 @@ class StubEnhancer {
 }
 
 class StubController {
-  shouldContinue(iteration) {
-    return iteration < 1;
+  shouldContinue(state) {
+    const iter = typeof state === 'object' ? state.iteration : state;
+    return iter < 1;
   }
 }
 


### PR DESCRIPTION
## Summary
- replace iteration controller call with object state including quality and gaps
- return confidence and gap lists from GapAnalyzer and DraftGenerator
- test IterationController with object state and update analyzer expectations

## Testing
- `npm test` *(fails: File not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895f9e386a083238c8494f57026244e