### PR TITLE
feat: archive unused memory entries

### DIFF
--- a/logic/archive_manager.js
+++ b/logic/archive_manager.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const fsp = fs.promises;
+const path = require('path');
+const { ensure_dir, normalize_memory_path } = require('../tools/file_utils');
+const { index_to_array, array_to_index } = require('../tools/index_utils');
+
+const indexFile = path.join(__dirname, '..', 'memory', 'index.json');
+
+async function archiveFile(filePath) {
+  if (!filePath) return null;
+  const normalized = normalize_memory_path(filePath);
+  const rel = normalized.replace(/^memory\//, '');
+  const archiveRel = path.posix.join('memory', 'archive', rel);
+  const src = path.join(__dirname, '..', normalized);
+  const dst = path.join(__dirname, '..', archiveRel);
+  ensure_dir(dst);
+  try {
+    await fsp.rename(src, dst);
+  } catch (e) {
+    // ignore file move errors
+  }
+
+  try {
+    const raw = await fsp.readFile(indexFile, 'utf-8');
+    const arr = index_to_array(JSON.parse(raw));
+    const idx = arr.findIndex(e => e.path === normalized);
+    if (idx >= 0) {
+      arr[idx].archived = true;
+      arr[idx].archivePath = archiveRel;
+      arr[idx].context_priority = 'low';
+      await fsp.writeFile(indexFile, JSON.stringify(array_to_index(arr), null, 2), 'utf-8');
+    }
+  } catch {
+    // ignore index update errors
+  }
+
+  return archiveRel;
+}
+
+module.exports = { archiveFile };

--- a/logic/index_manager.js
+++ b/logic/index_manager.js
@@ -22,14 +22,18 @@ const maxFiles = 15; // limit number of loaded files
 let indexData = null;
 let validationReport = null;
 
-function loadIndexSync() {
+function loadFullIndex() {
   try {
-    return sort_by_priority(index_tree.listAllEntries())
-      .filter(e => ['high', 'medium'].includes(e.context_priority || 'medium'))
-      .slice(0, maxFiles);
+    return sort_by_priority(index_tree.listAllEntries());
   } catch {
     return [];
   }
+}
+
+function loadIndexSync() {
+  return loadFullIndex()
+    .filter(e => ['high', 'medium'].includes(e.context_priority || 'medium'))
+    .slice(0, maxFiles);
 }
 
 function extractNumber(name) {
@@ -135,37 +139,37 @@ function getLessonByNumber(num) {
 }
 
 function getByPath(p) {
-  return loadIndexSync().find(e => e.path === p) || null;
+  return loadFullIndex().find(e => e.path === p || e.archivePath === p) || null;
 }
 
 function getByTag(tag) {
-  return loadIndexSync().filter(e => hasMatchingTag(e, tag));
+  return loadFullIndex().filter(e => hasMatchingTag(e, tag));
 }
 
 function filterByStatus(status) {
-  return loadIndexSync().filter(e => e.status === status);
+  return loadFullIndex().filter(e => e.status === status);
 }
 
 function filterByTags(tags) {
   const arr = Array.isArray(tags) ? tags : [tags];
-  return loadIndexSync().filter(e => arr.every(t => hasMatchingTag(e, t)));
+  return loadFullIndex().filter(e => arr.every(t => hasMatchingTag(e, t)));
 }
 
 function filterByDate(field, days) {
   const since = Date.now() - days * 24 * 60 * 60 * 1000;
-  return loadIndexSync().filter(e => {
+  return loadFullIndex().filter(e => {
     const ts = Date.parse(e[field]);
     return !isNaN(ts) && ts >= since;
   });
 }
 
 function filterByCategory(category) {
-  return loadIndexSync().filter(e => e.category === category);
+  return loadFullIndex().filter(e => e.category === category);
 }
 
 function searchByKeyword(query) {
   const re = new RegExp(query, 'i');
-  return loadIndexSync().filter(e => {
+  return loadFullIndex().filter(e => {
     const fields = [e.title, e.summary];
     if (Array.isArray(e.tags)) fields.push(...e.tags);
     return fields.some(v => v && re.test(String(v)));
@@ -219,7 +223,7 @@ async function updateMetadata(p, field, value) {
 }
 
 function validatePath(p) {
-  return !!loadIndexSync().find(e => e.path === p);
+  return !!loadFullIndex().find(e => e.path === p || e.archivePath === p);
 }
 
 


### PR DESCRIPTION
## Summary
- archive stale memory entries instead of deleting
- add archive manager for moving files and updating index
- search utilities load archived entries and resolve their archived paths
- allow reading archived files when primary path is missing

## Testing
- `npm test` *(fails: File not found: memory/lessons/04_example.md)*

------
https://chatgpt.com/codex/tasks/task_e_689608a1ef948323a7d6533290dd2ada