### PR TITLE
feat: add style mirror neuron

### DIFF
--- a/src/generator/neurons/StyleMirrorNeuron.js
+++ b/src/generator/neurons/StyleMirrorNeuron.js
@@ -1,0 +1,57 @@
+const MirrorNeuron = require('./MirrorNeuron');
+
+/**
+ * Neuron that mirrors high level writing style characteristics.
+ * Captures average sentence length, punctuation frequency and formality.
+ */
+class StyleMirrorNeuron extends MirrorNeuron {
+  /**
+   * Analyze the given text and extract style parameters.
+   * @param {string} input
+   * @returns {{avgSentenceLength:number, punctuationFrequency:number, formality:string}}
+   */
+  analyze(input = '') {
+    const sentences = input
+      .split(/[.!?]+/)
+      .map(s => s.trim())
+      .filter(Boolean);
+
+    const wordCounts = sentences.map(s => s.split(/\s+/).filter(Boolean).length);
+    const totalWords = wordCounts.reduce((a, b) => a + b, 0);
+    const avgSentenceLength = sentences.length ? totalWords / sentences.length : 0;
+
+    const words = input.split(/\s+/).filter(Boolean);
+    const punctuationMatches = input.match(/[.,!?:;]/g) || [];
+    const punctuationFrequency = words.length ? punctuationMatches.length / words.length : 0;
+
+    const contractions = input.match(/\b\w+'[a-zA-Z]+\b/g) || [];
+    const formality = contractions.length / (words.length || 1) > 0.05 ? 'informal' : 'formal';
+
+    this.style = { avgSentenceLength, punctuationFrequency, formality };
+    return this.style;
+  }
+
+  /**
+   * Generate text using stored style parameters.
+   * @param {Object} context - generation context (unused)
+   * @returns {string} styled text
+   */
+  generate(context = {}) {
+    const { avgSentenceLength = 10, punctuationFrequency = 0.1, formality = 'formal' } = this.style;
+
+    const baseFormal = 'This is a formal sentence';
+    const baseInformal = 'Hey this is an informal sentence';
+    const base = formality === 'informal' ? baseInformal : baseFormal;
+
+    const words = base.split(/\s+/);
+    const targetLength = Math.round(avgSentenceLength);
+    while (words.length < targetLength) {
+      words.push(formality === 'informal' ? 'really' : 'indeed');
+    }
+    let sentence = words.join(' ');
+    sentence += punctuationFrequency > 0.2 ? '!' : '.';
+    return sentence;
+  }
+}
+
+module.exports = StyleMirrorNeuron;

--- a/tests/neurons/style.test.js
+++ b/tests/neurons/style.test.js
@@ -1,0 +1,20 @@
+const assert = require('assert');
+const StyleMirrorNeuron = require('../../src/generator/neurons/StyleMirrorNeuron');
+
+function run() {
+  const neuron = new StyleMirrorNeuron();
+  const input = "Hello there! How are you doing? I'm fine.";
+  const style = neuron.analyze(input);
+
+  // avg sentence length: 8 words / 3 sentences
+  assert.ok(Math.abs(style.avgSentenceLength - 8 / 3) < 0.01, 'Average sentence length mismatch');
+  // punctuation frequency: 3 marks / 8 words
+  assert.ok(Math.abs(style.punctuationFrequency - 3 / 8) < 0.01, 'Punctuation frequency mismatch');
+  assert.strictEqual(style.formality, 'informal');
+
+  const generated = neuron.generate();
+  assert.ok(generated.endsWith('!'), 'Generated text should reflect punctuation style');
+  console.log('StyleMirrorNeuron tests passed');
+}
+
+run();

--- a/tests/runAll.js
+++ b/tests/runAll.js
@@ -4,13 +4,22 @@ const { execFileSync } = require('child_process');
 
 const testDir = __dirname;
 
-const files = fs
-  .readdirSync(testDir)
-  .filter(f => f.endsWith('.test.js'))
-  .sort();
+const files = [];
+function collect(dir) {
+  fs.readdirSync(dir).forEach(f => {
+    const p = path.join(dir, f);
+    if (fs.statSync(p).isDirectory()) {
+      collect(p);
+    } else if (f.endsWith('.test.js')) {
+      files.push(p);
+    }
+  });
+}
+
+collect(testDir);
+files.sort();
 
 files.forEach(file => {
-  const p = path.join(testDir, file);
-  console.log(`Running ${file}`);
-  execFileSync('node', [p], { stdio: 'inherit' });
+  console.log(`Running ${path.relative(testDir, file)}`);
+  execFileSync('node', [file], { stdio: 'inherit' });
 });


### PR DESCRIPTION
## Summary
- add StyleMirrorNeuron to analyze sentence length, punctuation frequency and formality
- generate text using stored style parameters
- expand test runner to recurse into subdirectories
- cover StyleMirrorNeuron with unit test

## Testing
- `node tests/neurons/style.test.js`
- `npm test` *(fails: File not found: memory/lessons/04_example.md)*

------
https://chatgpt.com/codex/tasks/task_e_6897412e19d883238e3ab8371a8a19b4