### PR TITLE
feat: add emotion mirroring neuron

### DIFF
--- a/src/generator/neurons/EmotionMirrorNeuron.js
+++ b/src/generator/neurons/EmotionMirrorNeuron.js
@@ -1,0 +1,54 @@
+const MirrorNeuron = require('./MirrorNeuron');
+
+/**
+ * Neuron that mirrors emotional tone from input text.
+ */
+class EmotionMirrorNeuron extends MirrorNeuron {
+  constructor() {
+    super();
+    this.emotion = 'neutral';
+  }
+
+  /**
+   * Analyze input text to detect simple emotional tone.
+   * @param {string} input - sample text whose emotion should be mirrored
+   * @returns {Object} stored style parameters including emotion
+   */
+  analyze(input = '') {
+    const style = super.analyze(input);
+    const lower = input.toLowerCase();
+    const dictionary = {
+      happy: ['happy', 'joy', 'glad', 'excited', 'love'],
+      sad: ['sad', 'down', 'unhappy', 'depressed', 'cry'],
+      angry: ['angry', 'mad', 'furious', 'irritated', 'hate']
+    };
+
+    this.emotion = 'neutral';
+    for (const [emotion, words] of Object.entries(dictionary)) {
+      if (words.some(w => lower.includes(w))) {
+        this.emotion = emotion;
+        break;
+      }
+    }
+
+    return { ...style, emotion: this.emotion };
+  }
+
+  /**
+   * Generate text with mirrored emotion.
+   * @param {Object} context - generation context
+   * @param {string} context.text - base text to mirror
+   * @returns {string} emotion-enhanced text
+   */
+  generate(context = {}) {
+    const base = super.generate(context);
+    const additions = {
+      happy: ' Yay! 😊',
+      sad: ' Oh no... 😢',
+      angry: ' Grr! 😠'
+    };
+    return base + (additions[this.emotion] || '');
+  }
+}
+
+module.exports = EmotionMirrorNeuron;

--- a/tests/neurons/emotion.test.js
+++ b/tests/neurons/emotion.test.js
@@ -1,0 +1,20 @@
+const assert = require('assert');
+const EmotionMirrorNeuron = require('../../src/generator/neurons/EmotionMirrorNeuron');
+
+function run() {
+  const happyNeuron = new EmotionMirrorNeuron();
+  const happyStyle = happyNeuron.analyze('I am so happy and excited today!');
+  assert.strictEqual(happyStyle.emotion, 'happy');
+  const happyGenerated = happyNeuron.generate({ text: 'hello' });
+  assert.ok(happyGenerated.includes('😊'), 'Happy emoji missing');
+
+  const sadNeuron = new EmotionMirrorNeuron();
+  const sadStyle = sadNeuron.analyze('This is a sad and depressing moment.');
+  assert.strictEqual(sadStyle.emotion, 'sad');
+  const sadGenerated = sadNeuron.generate({ text: 'hello' });
+  assert.ok(sadGenerated.includes('😢'), 'Sad emoji missing');
+
+  console.log('EmotionMirrorNeuron tests passed');
+}
+
+run();


### PR DESCRIPTION
## Summary
- add `EmotionMirrorNeuron` that detects emotional tone and appends matching phrases/emoji
- cover emotion mirroring behavior with tests

## Testing
- `node tests/neurons/emotion.test.js`
- `npm test` *(fails: File not found: memory/lessons/04_example.md)*
- `npx eslint src/generator/neurons/EmotionMirrorNeuron.js tests/neurons/emotion.test.js` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689746c4839c83238b49456b55bc0e35