### PR TITLE
Add structure-based mirror neuron

### DIFF
--- a/src/generator/neurons/StructureMirrorNeuron.js
+++ b/src/generator/neurons/StructureMirrorNeuron.js
@@ -1,0 +1,85 @@
+const MirrorNeuron = require('./MirrorNeuron');
+
+/**
+ * Neuron that mirrors sentence structure characteristics such as
+ * sentence types and passive voice frequency.
+ */
+class StructureMirrorNeuron extends MirrorNeuron {
+  /**
+   * Analyze input text to capture sentence structure information.
+   * @param {string} input
+   * @returns {Object} stored structure parameters
+   */
+  analyze(input = '') {
+    const baseStyle = super.analyze(input);
+    const sentences = input.match(/[^.!?]+[.!?]/g) || [];
+    const passiveRegex = /\b(be|am|is|are|was|were|been|being)\b\s+\w+ed\b/i;
+
+    const counts = { declarative: 0, interrogative: 0, exclamatory: 0 };
+    const order = [];
+    let passiveCount = 0;
+
+    sentences.forEach(s => {
+      const trimmed = s.trim();
+      const last = trimmed.slice(-1);
+      let type;
+      if (last === '?') {
+        type = 'interrogative';
+      } else if (last === '!') {
+        type = 'exclamatory';
+      } else {
+        type = 'declarative';
+      }
+      counts[type]++;
+      order.push(type);
+      if (passiveRegex.test(trimmed)) passiveCount++;
+    });
+
+    const total = sentences.length || 1;
+    this.style = {
+      ...baseStyle,
+      structure: counts,
+      order,
+      passiveRatio: passiveCount / total
+    };
+    return this.style;
+  }
+
+  /**
+   * Generate sentences that mimic analyzed structure.
+   * @param {Object} context - generation context (unused)
+   * @returns {string} generated text
+   */
+  generate(context = {}) { // eslint-disable-line no-unused-vars
+    const { order = [], passiveRatio = 0 } = this.style;
+    const templates = {
+      declarative: {
+        active: 'The cat eats the food.',
+        passive: 'The food is eaten by the cat.'
+      },
+      interrogative: {
+        active: 'Does the cat eat the food?',
+        passive: 'Is the food eaten by the cat?'
+      },
+      exclamatory: {
+        active: 'The cat eats the food!',
+        passive: 'The food is eaten by the cat!'
+      }
+    };
+
+    const totalSentences = order.length;
+    const passiveCount = Math.round(passiveRatio * totalSentences);
+    let usedPassive = 0;
+    const result = [];
+
+    order.forEach(type => {
+      const usePassive = usedPassive < passiveCount;
+      result.push(templates[type][usePassive ? 'passive' : 'active']);
+      if (usePassive) usedPassive++;
+    });
+
+    return this.mirror(result.join(' '));
+  }
+}
+
+module.exports = StructureMirrorNeuron;

--- a/tests/neurons/structure.test.js
+++ b/tests/neurons/structure.test.js
@@ -1,0 +1,25 @@
+const assert = require('assert');
+const StructureMirrorNeuron = require('../../src/generator/neurons/StructureMirrorNeuron');
+
+function run() {
+  const neuron = new StructureMirrorNeuron();
+  const input = 'The ball was kicked by John. Did Mary catch it? What a great game!';
+  const style = neuron.analyze(input);
+
+  assert.strictEqual(style.structure.declarative, 1);
+  assert.strictEqual(style.structure.interrogative, 1);
+  assert.strictEqual(style.structure.exclamatory, 1);
+  assert.ok(Math.abs(style.passiveRatio - 1 / 3) < 0.01, 'Passive ratio mismatch');
+
+  const output = neuron.generate();
+  const sentences = output.match(/[^.!?]+[.!?]/g) || [];
+  assert.strictEqual(sentences.length, 3, 'Should generate same number of sentences');
+  assert.ok(sentences[0].trim().endsWith('.'), 'First sentence should be declarative');
+  assert.ok(sentences[1].trim().endsWith('?'), 'Second sentence should be interrogative');
+  assert.ok(sentences[2].trim().endsWith('!'), 'Third sentence should be exclamatory');
+  assert.ok(sentences.some(s => /\b(be|am|is|are|was|were|been|being)\b/.test(s) && /by/.test(s)), 'Passive voice missing');
+
+  console.log('StructureMirrorNeuron tests passed');
+}
+
+run();


### PR DESCRIPTION
## Summary
- implement `StructureMirrorNeuron` to capture sentence types and passive voice frequency
- generate sentences matching analyzed structure
- add tests for different sentence structures and passive voice detection

## Testing
- `node tests/neurons/structure.test.js`
- `node tests/neurons/style.test.js`
- `node tests/neurons/emotion.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68974bb7b90483238e423afa85cd2530