### PR TITLE
feat: integrate mirror neurons into draft generation

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -6,5 +6,6 @@
   "pluginRepo": {
     "repo": "https://github.com/redvampir/sofia-memory-plugin.git",
     "token": null
-  }
+  },
+  "mirrorNeurons": []
 }

--- a/config/index.js
+++ b/config/index.js
@@ -35,8 +35,17 @@ function getStudentRepo() {
   };
 }
 
-function loadConfig() {
-  return { pluginRepo: getPluginRepo(), studentRepo: getStudentRepo() };
+function getMirrorNeurons() {
+  const list = loadFromFile().mirrorNeurons;
+  return Array.isArray(list) ? list : [];
 }
 
-module.exports = { loadConfig, getPluginRepo, getStudentRepo };
+function loadConfig() {
+  return {
+    pluginRepo: getPluginRepo(),
+    studentRepo: getStudentRepo(),
+    mirrorNeurons: getMirrorNeurons(),
+  };
+}
+
+module.exports = { loadConfig, getPluginRepo, getStudentRepo, getMirrorNeurons };

--- a/src/generator/neurons/index.js
+++ b/src/generator/neurons/index.js
@@ -1,0 +1,14 @@
+const BaseNeuron = require('./BaseNeuron');
+const MirrorNeuron = require('./MirrorNeuron');
+const EmotionMirrorNeuron = require('./EmotionMirrorNeuron');
+const StructureMirrorNeuron = require('./StructureMirrorNeuron');
+const StyleMirrorNeuron = require('./StyleMirrorNeuron');
+
+module.exports = {
+  BaseNeuron,
+  MirrorNeuron,
+  EmotionMirrorNeuron,
+  StructureMirrorNeuron,
+  StyleMirrorNeuron,
+};
+

--- a/tests/draft/mirror-neurons.test.js
+++ b/tests/draft/mirror-neurons.test.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+
+(async () => {
+  const cfgPath = path.join(__dirname, '..', '..', 'config', 'config.json');
+  const original = fs.readFileSync(cfgPath, 'utf8');
+  const cfg = JSON.parse(original);
+  cfg.mirrorNeurons = ['StyleMirrorNeuron', 'EmotionMirrorNeuron'];
+  fs.writeFileSync(cfgPath, JSON.stringify(cfg, null, 2));
+
+  try {
+    const DraftGenerator = require('../../src/generator/draft/DraftGenerator');
+    const generator = new DraftGenerator();
+    const result = await generator.generate('I am so happy and excited today!');
+    assert(
+      result.text.includes('formal sentence') ||
+        result.text.includes('informal sentence'),
+      'style neuron output missing'
+    );
+    assert(result.text.includes('😊'), 'emotion neuron output missing');
+    console.log('mirror neurons test passed');
+  } finally {
+    fs.writeFileSync(cfgPath, original);
+  }
+})();


### PR DESCRIPTION
## Summary
- centralize neuron exports via generator/neurons index
- allow DraftGenerator to initialize configured mirror neurons
- add configuration for active mirror neurons and new test covering multiple neurons

## Testing
- `npm test` *(fails: memory_functions.test.js: File not found)*
- `node tests/draft/mirror-neurons.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68974f9da4dc8323892546b5a544c526