### PR TITLE
feat: load mirror neurons for world generation

### DIFF
--- a/src/generator/world/WorldGenerator.js
+++ b/src/generator/world/WorldGenerator.js
@@ -1,0 +1,92 @@
+const fs = require('fs');
+const path = require('path');
+const availableNeurons = require('../neurons');
+
+const STATE_TO_CLASS = {
+  style: 'StyleMirrorNeuron',
+  emotion: 'EmotionMirrorNeuron',
+  structure: 'StructureMirrorNeuron'
+};
+
+/**
+ * Generator responsible for building a world description.
+ * It can incorporate previously saved mirror neuron states if available.
+ */
+class WorldGenerator {
+  constructor(opts = {}) {
+    this.neurons = [];
+    this.baseSettings = opts.baseSettings || {};
+  }
+
+  /**
+   * Prepare generation context and load mirror neurons if a path is provided.
+   *
+   * @param {Object} context
+   * @param {string} [context.mirrorNeuronsPath] - path to saved neuron state
+   * @returns {Object} the original context
+   */
+  prepareContext(context = {}) {
+    const p = context.mirrorNeuronsPath;
+    this.neurons = [];
+
+    if (p) {
+      const abs = path.resolve(p);
+      if (fs.existsSync(abs)) {
+        try {
+          const raw = fs.readFileSync(abs, 'utf8');
+          const data = JSON.parse(raw);
+          for (const [key, state] of Object.entries(data || {})) {
+            const clsName = STATE_TO_CLASS[key];
+            const Neuron = availableNeurons[clsName];
+            if (Neuron && state) {
+              const n = new Neuron();
+              n.style = state;
+              if (key === 'emotion' && state.emotion) {
+                n.emotion = state.emotion;
+              }
+              this.neurons.push(n);
+            }
+          }
+        } catch (e) {
+          // ignore parse errors and fall back to base settings
+          this.neurons = [];
+        }
+      }
+    }
+
+    return context;
+  }
+
+  /**
+   * Generate world data. Before finalizing the world, each loaded neuron
+   * will generate using the provided context.
+   * Fallback to base settings if no neurons are loaded.
+   *
+   * @param {Object} context
+   * @returns {Object} world description
+   */
+  generate(context = {}) {
+    const world = { ...(context.baseWorld || this.baseSettings) };
+
+    if (!this.neurons.length) {
+      return world;
+    }
+
+    const outputs = [];
+    for (const neuron of this.neurons) {
+      try {
+        outputs.push(neuron.generate(context));
+      } catch (_) {
+        // ignore individual neuron errors
+      }
+    }
+
+    if (outputs.length) {
+      world.mirrorNeurons = outputs;
+    }
+
+    return world;
+  }
+}
+
+module.exports = WorldGenerator;

--- a/tests/world/world-generator.test.js
+++ b/tests/world/world-generator.test.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const WorldGenerator = require('../../src/generator/world/WorldGenerator');
+
+(async () => {
+  const tmpDir = path.join(__dirname, '..', 'tmp_world');
+  fs.mkdirSync(tmpDir, { recursive: true });
+  const file = path.join(tmpDir, 'book.json');
+  const state = {
+    style: { avgSentenceLength: 5, punctuationFrequency: 0.1, formality: 'informal' },
+    emotion: { isUpper: false, isLower: false, lastChar: '.', emotion: 'happy' },
+    structure: { order: ['declarative'], passiveRatio: 0 }
+  };
+  fs.writeFileSync(file, JSON.stringify(state, null, 2));
+
+  const gen = new WorldGenerator();
+  gen.prepareContext({ mirrorNeuronsPath: file });
+  const world = gen.generate({ text: 'example', baseWorld: { base: true } });
+  assert(world.mirrorNeurons && world.mirrorNeurons.length === 3, 'neurons not generated');
+
+  const gen2 = new WorldGenerator({ baseSettings: { base: true } });
+  gen2.prepareContext({ mirrorNeuronsPath: path.join(tmpDir, 'missing.json') });
+  const world2 = gen2.generate({});
+  assert.deepStrictEqual(world2, { base: true }, 'fallback to base settings failed');
+
+  console.log('world generator test passed');
+})();


### PR DESCRIPTION
## Summary
- load saved mirror neurons from `mirrorNeuronsPath` in world generator context
- invoke each neuron's `generate` before finalizing world data
- fallback to base settings when no mirror neurons are available
- add unit test for world generator neuron loading and fallback

## Testing
- `node tests/world/world-generator.test.js`
- `npm test` *(fails: File not found: memory/lessons/intro.md & assertion in index_manager_validation.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6897664079e083238fb6ed21e2b902e4