### PR TITLE
feat: add book importer

### DIFF
--- a/src/books/BookImporter.js
+++ b/src/books/BookImporter.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const path = require('path');
+
+function slugify(text = '') {
+  return String(text)
+    .toLowerCase()
+    .trim()
+    .replace(/[^\p{Letter}\p{Number}]+/gu, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function importBook(bookId, filePath) {
+  if (!bookId) throw new Error('bookId required');
+  if (!fs.existsSync(filePath)) throw new Error(`file not found: ${filePath}`);
+
+  const baseDir = path.join(__dirname, '..', '..', 'memory', 'books', bookId);
+  fs.mkdirSync(baseDir, { recursive: true });
+
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const headingRegex = /^#\s+(.+)$/gm;
+  const matches = [];
+  let m;
+  while ((m = headingRegex.exec(content)) !== null) {
+    matches.push({ title: m[1].trim(), index: m.index });
+  }
+  if (matches.length === 0) {
+    matches.push({ title: 'chapter-1', index: 0 });
+  }
+  matches.push({ index: content.length });
+
+  const index = [];
+  for (let i = 0; i < matches.length - 1; i++) {
+    const { title, index: start } = matches[i];
+    const end = matches[i + 1].index;
+    const chapterContent = content.slice(start, end).trim();
+    const fileName = `${slugify(title) || `chapter-${i + 1}`}.md`;
+    const outPath = path.join(baseDir, fileName);
+    fs.writeFileSync(outPath, chapterContent, 'utf-8');
+    index.push({ title, file: fileName, offset: start });
+  }
+
+  const indexPath = path.join(baseDir, 'index.json');
+  fs.writeFileSync(indexPath, JSON.stringify(index, null, 2), 'utf-8');
+  return index;
+}
+
+module.exports = { importBook };

--- a/tests/books/book-importer.test.js
+++ b/tests/books/book-importer.test.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const { importBook } = require('../../src/books/BookImporter');
+
+const tmpDir = path.join(__dirname, 'tmp');
+if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir, { recursive: true });
+
+function run() {
+  const bookId = 'sample-book';
+  const bookFile = path.join(tmpDir, 'book.md');
+  const content = '# Intro\nIntro text\n\n# Chapter Two\nSecond text';
+  fs.writeFileSync(bookFile, content, 'utf-8');
+
+  importBook(bookId, bookFile);
+
+  const bookDir = path.join(__dirname, '..', '..', 'memory', 'books', bookId);
+  const ch1 = path.join(bookDir, 'intro.md');
+  const ch2 = path.join(bookDir, 'chapter-two.md');
+
+  assert.ok(fs.existsSync(ch1), 'first chapter file exists');
+  assert.ok(fs.existsSync(ch2), 'second chapter file exists');
+  assert.strictEqual(fs.readFileSync(ch1, 'utf-8').trim(), '# Intro\nIntro text');
+  assert.strictEqual(fs.readFileSync(ch2, 'utf-8').trim(), '# Chapter Two\nSecond text');
+
+  const indexPath = path.join(bookDir, 'index.json');
+  assert.ok(fs.existsSync(indexPath), 'index file exists');
+  const index = JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
+  assert.strictEqual(index.length, 2, 'two chapters indexed');
+  assert.deepStrictEqual(index.map(c => c.title), ['Intro', 'Chapter Two']);
+  assert.strictEqual(index[1].offset, content.indexOf('# Chapter Two'));
+
+  fs.rmSync(bookDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  console.log('book importer tests passed');
+}
+
+module.exports = run;
+if (require.main === module) run();

--- a/tests/memory_dynamic_index_update.test.js
+++ b/tests/memory_dynamic_index_update.test.js
@@ -22,6 +22,6 @@ const index_manager = require('../logic/index_manager');
   found = index_manager.getByPath(fileRel);
   assert.ok(found && found.path===fileRel);
 
-  fs.rmSync(path.dirname(abs),{recursive:true,force:true});
+  fs.rmSync(abs, { force: true });
   console.log('memory dynamic index update tests passed');
 })();


### PR DESCRIPTION
## Summary
- add book importer to split markdown books into chapter files with an index
- test importer for chapter extraction and index generation
- keep lesson files when updating dynamic index tests

## Testing
- `node tests/books/book-importer.test.js`
- `npm test` *(fails: AssertionError [ERR_ASSERTION]: restoreContext should be called when context missing)*

------
https://chatgpt.com/codex/tasks/task_e_68977051421c8323a494c03be60efcb1