### PR TITLE
feat: add basic memory neurons with linking

### DIFF
--- a/src/memory/neurons/BaseMemoryNeuron.js
+++ b/src/memory/neurons/BaseMemoryNeuron.js
@@ -1,0 +1,11 @@
+class BaseMemoryNeuron {
+  extract(text) {
+    throw new Error('extract() must be implemented by subclasses');
+  }
+
+  toJSON() {
+    return { type: this.constructor.name };
+  }
+}
+
+module.exports = BaseMemoryNeuron;

--- a/src/memory/neurons/BookMemoryNeuron.js
+++ b/src/memory/neurons/BookMemoryNeuron.js
@@ -1,0 +1,28 @@
+const BaseMemoryNeuron = require('./BaseMemoryNeuron');
+
+class BookMemoryNeuron extends BaseMemoryNeuron {
+  constructor() {
+    super();
+    this.references = [];
+  }
+
+  extract(text) {
+    return text;
+  }
+
+  link(neuron) {
+    if (!(neuron instanceof BaseMemoryNeuron)) {
+      throw new Error('link() expects a BaseMemoryNeuron instance');
+    }
+    this.references.push(neuron);
+  }
+
+  toJSON() {
+    return {
+      ...super.toJSON(),
+      references: this.references.map(ref => ref.toJSON()),
+    };
+  }
+}
+
+module.exports = BookMemoryNeuron;

--- a/src/memory/neurons/index.js
+++ b/src/memory/neurons/index.js
@@ -1,0 +1,7 @@
+const BaseMemoryNeuron = require('./BaseMemoryNeuron');
+const BookMemoryNeuron = require('./BookMemoryNeuron');
+
+module.exports = {
+  BaseMemoryNeuron,
+  BookMemoryNeuron,
+};

--- a/tests/memory/base-memory-neuron.test.js
+++ b/tests/memory/base-memory-neuron.test.js
@@ -1,0 +1,18 @@
+const assert = require('assert');
+const { BookMemoryNeuron } = require('../../src/memory/neurons');
+
+// Test serialization
+const neuron = new BookMemoryNeuron();
+const json = neuron.toJSON();
+assert.strictEqual(json.type, 'BookMemoryNeuron');
+assert.deepStrictEqual(json.references, []);
+
+// Test linking
+const a = new BookMemoryNeuron();
+const b = new BookMemoryNeuron();
+a.link(b);
+const linked = a.toJSON();
+assert.strictEqual(linked.references.length, 1);
+assert.strictEqual(linked.references[0].type, 'BookMemoryNeuron');
+
+console.log('BaseMemoryNeuron tests passed');


### PR DESCRIPTION
## Summary
- add BaseMemoryNeuron with basic extract and JSON serialization
- implement BookMemoryNeuron with references and linking support
- export memory neurons and add unit tests

## Testing
- `npm test` *(fails: File not found: memory/lessons/04_example/index.md)*
- `node tests/memory/base-memory-neuron.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689771f9adec8323bfbdeeeaf8a2d5c0